### PR TITLE
Fix auto-attack pre-damage highlight window click lock

### DIFF
--- a/apps/home/interaction/auto-attack-highlight-click-lock.spec.ts
+++ b/apps/home/interaction/auto-attack-highlight-click-lock.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+
+// Issue #178: a click landing inside the ~400ms pre-damage attack-highlight
+// window (ADR-0004's ATTACK_HIGHLIGHT_DELAY_MS, shown via updateHighlights()
+// in handleTileClick — main/game_world.ts) used to re-enter handleTileClick
+// while the pending attackUnit() dispatch was still in flight, because
+// isAutoPathing was already reset to false by the time the highlight delay
+// started and canAcceptInput() had nothing left to check. This drives a real
+// click timed into that window and asserts it has no effect at all: the Hero
+// doesn't walk off to a second destination mid-delay, and the already-decided
+// auto-attack still resolves normally afterward.
+test("a click during the auto-attack highlight window is ignored", async ({
+  page,
+}) => {
+  await page.goto("/interaction-harness?enemy=1");
+
+  await expect
+    .poll(() => page.evaluate(() => window.__test?.getUnitSectionByOwner("human")))
+    .toBe("harness_start");
+  await expect
+    .poll(() => page.evaluate(() => window.__test?.getUnitSectionByOwner("harness_enemy")))
+    .toBe("harness_enemy_spot");
+
+  const start = await page.evaluate(() =>
+    window.__test!.getTileScreenPositionBySection("harness_start")
+  );
+  const next = await page.evaluate(() =>
+    window.__test!.getTileScreenPositionBySection("harness_next")
+  );
+  // The Hero (move budget 3) has plenty left after the 1-step move onto
+  // "harness_next" — a click here would be a perfectly legal further move if
+  // input weren't locked, which is exactly what makes it a meaningful probe
+  // of the highlight window.
+  const far = await page.evaluate(() =>
+    window.__test!.getTileScreenPositionBySection("harness_far")
+  );
+  if (!start || !next || !far) throw new Error("harness tiles not found on screen");
+
+  await page.mouse.click(start.x, start.y); // select the Hero
+  await page.mouse.click(next.x, next.y); // auto-paths adjacent to the single enemy
+
+  // Timeline after the click above: ~600ms move tween (shared/game_world.ts's
+  // Move case: 100ms delay + 500ms tween), then the ~400ms attack-highlight
+  // delay this issue is about. 700ms lands inside that highlight window,
+  // after the move has finished animating but before the pending attack
+  // resolves.
+  await page.waitForTimeout(700);
+  await page.mouse.click(far.x, far.y); // must be swallowed, not queued or acted on
+
+  // Give the auto-attack's own delay+dispatch time to finish.
+  await expect
+    .poll(() => page.evaluate(() => window.__test?.isSectionOccupied("harness_enemy_spot")))
+    .toBe(false);
+
+  // The stray click had no effect: the Hero is still where the auto-attack
+  // left it, not off at "harness_far".
+  expect(
+    await page.evaluate(() => window.__test?.getUnitSectionByOwner("human"))
+  ).toBe("harness_next");
+});

--- a/apps/home/src/game/main/game_world.ts
+++ b/apps/home/src/game/main/game_world.ts
@@ -47,6 +47,15 @@ export class MainWorld extends GameWorld {
   // while handleTileClick's loop is still awaiting the next one.
   protected isAutoPathing = false;
 
+  // True while the pre-damage attack-highlight delay (ADR-0004,
+  // ATTACK_HIGHLIGHT_DELAY_MS) is in flight after a move auto-attacked an
+  // unambiguous target. Deliberately a separate flag from isAutoPathing
+  // (already false by this point — that one covers only the move loop
+  // itself): canAcceptInput() must also block input here, since
+  // attackUnit()'s dispatch is still pending and a re-entrant click could
+  // select/move a second unit concurrently with it (issue #178).
+  protected isAwaitingAutoAttackHighlight = false;
+
   // World-space layer for the selected unit's valid-move highlights (spec 03).
   // Lives in the viewport so highlights pan/zoom with the board.
   protected highlightContainer: Container = new Container();
@@ -341,7 +350,8 @@ export class MainWorld extends GameWorld {
       this.isPlayerTurn &&
       !this.dialogActive &&
       !this.isUnitMoving &&
-      !this.isAutoPathing
+      !this.isAutoPathing &&
+      !this.isAwaitingAutoAttackHighlight
     );
   }
 
@@ -488,7 +498,12 @@ export class MainWorld extends GameWorld {
       if (targets.length === 1) {
         this.selectedUnit = moved;
         this.updateHighlights(); // shows the attack-target frame before damage lands
-        await this.delay(ATTACK_HIGHLIGHT_DELAY_MS);
+        this.isAwaitingAutoAttackHighlight = true;
+        try {
+          await this.delay(ATTACK_HIGHLIGHT_DELAY_MS);
+        } finally {
+          this.isAwaitingAutoAttackHighlight = false;
+        }
         if (this.isDestroyed) {
           // Torn down while the highlight delay was in flight (issue #175) —
           // the reducer/scenario are still safe to call (they're plain


### PR DESCRIPTION
Closes #178.

## Summary
`handleTileClick`'s post-move auto-attack (ADR-0004) reset `isAutoPathing` to `false` in the move loop's `finally` before showing the attack-target frame and awaiting `ATTACK_HIGHLIGHT_DELAY_MS` (~400ms) prior to dispatching `attackUnit()`. `canAcceptInput()` had no guard covering that window, so a click landing inside it could re-enter `handleTileClick` while the pending attack's dispatch was still in flight, letting a second unit be selected/moved concurrently.

## Fix
Adds a dedicated `isAwaitingAutoAttackHighlight` flag (kept separate from `isAutoPathing`, whose semantics are specifically about the multi-step path-walking loop), set `true` right before the highlight delay starts and cleared in a `finally` once it resolves, wired into `canAcceptInput()` alongside the existing guards.

## Test plan
- [x] `npx tsc --noEmit -p .`
- [x] `npx astro check` (0 errors)
- [x] `npx vitest run` (395 passed)
- [x] `npx playwright test` (7 passed), including new `interaction/auto-attack-highlight-click-lock.spec.ts`
- [x] Sanity-checked the new interaction test: `git stash`'d the production fix and confirmed the test fails against the old code, then restored the fix and confirmed it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)