### PR TITLE
Rename moveRange to sightRadius in Move reducer case

### DIFF
--- a/apps/home/src/game/core/reducers/index.ts
+++ b/apps/home/src/game/core/reducers/index.ts
@@ -103,10 +103,10 @@ export function gameReducer(state: State, action: GameEvent) {
       }
 
       if (isMovable(action.unit)) action.unit.step(1);
-      const moveRange = isSightful(action.unit) ? action.unit.sightRange : 0;
+      const sightRadius = isSightful(action.unit) ? action.unit.sightRange : 0;
       const revealedAfterMove =
-        movingUnit && moveRange > 0
-          ? revealAround(state, movingUnit.owner, action.position, moveRange)
+        movingUnit && sightRadius > 0
+          ? revealAround(state, movingUnit.owner, action.position, sightRadius)
           : state.revealedTiles;
       return {
         ...state,


### PR DESCRIPTION
## Summary
- Closes #180.
- The local variable `moveRange` in the `Move` case of `gameReducer` (`apps/home/src/game/core/reducers/index.ts`) actually held a unit's sight radius (`isSightful(action.unit) ? action.unit.sightRange : 0`), not the "Move range" domain concept that `core/player/movement.ts` already exports as a function of the same name.
- Renamed it to `sightRadius` to remove the Mysterious-Name collision. The `Spawn` case already used `spawnRange`, so no change was needed there.
- Pure rename, no behavior change.

## Test plan
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx vitest run` — 395 tests passed (37 files), including `apps/home/src/game/core/reducers/index.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)