### PR TITLE
Remove dead ship/intro-sheet placeholder unit-texture code

### DIFF
--- a/apps/home/src/game/main/preload.ts
+++ b/apps/home/src/game/main/preload.ts
@@ -1,7 +1,5 @@
 import image from "../assets/sprites/board1-0.png";
 import data from "../assets/sprites/board1-0.json";
-import introImage from "../assets/sprites/intro-0.png";
-import introData from "../assets/sprites/intro-0.json";
 import unitsImage from "../assets/sprites/units-0.png";
 import unitsData from "../assets/sprites/units-0.json";
 import { Spritesheet, Assets } from "pixi.js";
@@ -11,11 +9,6 @@ export async function preload() {
   const boardTexture = await Assets.load("board1");
   const sheet = new Spritesheet(boardTexture.source, data);
   await sheet.parse();
-
-  // Load intro sheet to make unit textures (ship) available globally
-  const introTexture = await Assets.load(introImage.src);
-  const introSheet = new Spritesheet(introTexture.source, introData);
-  await introSheet.parse();
 
   // Load the dedicated units sheet (gh #192) to make its textures (hero,
   // wanderer, wolf, bandit, banditCaptain) available globally the same way —

--- a/apps/home/src/game/main/stage_manager.ts
+++ b/apps/home/src/game/main/stage_manager.ts
@@ -74,9 +74,11 @@ export class StageManager extends Container {
     }
 
     // No `texture`/`baseTexture` here (unlike game_loader.ts's own destroy
-    // call for the intro viewport): board tiles and unit sprites read from
-    // the shared `sheet`/global "ship" texture the *next* MainWorld reuses —
-    // destroying those would break its rendering, not just this one's.
+    // call for the intro viewport): board tiles read from the shared `sheet`
+    // and unit sprites read from the globally-registered per-type textures
+    // (hero/wanderer/wolf/bandit/banditCaptain, gh #192) that the *next*
+    // MainWorld reuses — destroying those would break its rendering, not
+    // just this one's.
     this.removeChild(this.mainWorld);
     this.mainWorld.destroy({ children: true });
 

--- a/apps/home/src/game/shared/game_world.ts
+++ b/apps/home/src/game/shared/game_world.ts
@@ -25,15 +25,13 @@ import type { Unit } from "../core/units";
 import type { IRenderable } from "./renderable/renderable";
 
 // Duck-typed rather than a static `Unit & IRenderable` param type: not every
-// `Unit` is guaranteed Renderable (e.g. a bare test double), and core/game_event.ts
-// can't import shared's IRenderable without inverting the core->shared layering.
+// `Unit` is guaranteed Renderable — e.g. main/harness/interaction_harness.ts's
+// HarnessTarget is a plain Damageable(Unit) test stand-in with no icon of its
+// own — and core/game_event.ts can't import shared's IRenderable without
+// inverting the core->shared layering.
 function isRenderable(unit: Unit): unit is Unit & IRenderable {
   return typeof (unit as Partial<IRenderable>).textureName === "string";
 }
-
-// Fallback for a unit with no Renderable mixin applied (see isRenderable) —
-// keeps the old shared "ship" placeholder rather than throwing.
-const FALLBACK_UNIT_TEXTURE = "ship";
 
 const FOG_HEX_SIZE = 50;
 const FOG_HEX_Y_OFFSET = 4;
@@ -134,15 +132,15 @@ export class GameWorld extends Container {
 
           // Layer 2: unit sprite on top, picked by type (gh #192) — each
           // concrete unit class sets its own textureName via the Renderable
-          // mixin (shared/renderable). scale.x flip is a leftover from the
-          // old shared "ship" icon; kept for now, see gh #194.
-          const unitTextureName = isRenderable(action.unit)
-            ? action.unit.textureName
-            : FALLBACK_UNIT_TEXTURE;
-          const unitTexture = Texture.from(unitTextureName);
-          const unitSprite = new Tile(unitTexture, action.position);
-          unitSprite.scale.x = -1;
-          unitContainer.addChild(unitSprite);
+          // mixin (shared/renderable). Non-Renderable units (e.g. harness
+          // test stand-ins) render with just the colored hex background —
+          // there's no per-type icon to fall back to since gh #194 removed
+          // the old shared "ship" placeholder.
+          if (isRenderable(action.unit)) {
+            const unitTexture = Texture.from(action.unit.textureName);
+            const unitSprite = new Tile(unitTexture, action.position);
+            unitContainer.addChild(unitSprite);
+          }
 
           this.unitSprites.set(action.unit.id, unitContainer);
           this.unitContainer.addChild(unitContainer);


### PR DESCRIPTION
Closes #194.

Before gh #192, every main-game unit rendered with a shared `"ship"` icon as a lazy placeholder, loaded globally by `main/preload.ts`'s side-effect import of the intro sheet. #192 wired real per-type unit textures (hero/wanderer/wolf/bandit/banditCaptain) but deliberately left the old plumbing in place, blocked on this ticket.

## Removed
- `main/preload.ts`: the block that loaded `intro-0.png`/`.json` purely to register the `"ship"` frame globally, plus its now-unused imports.
- `shared/game_world.ts`: the `FALLBACK_UNIT_TEXTURE = "ship"` constant and the unconditional `scale.x = -1` flip. The flip was a workaround for the old single generic icon — the new per-type art in `assets_gen/unit_sprites.ts` is drawn facing right by design (the hero's sword arm, the wolf's nose/eye, the bandits' blades all sit at higher x), so the flip is no longer wanted.
- `stage_manager.ts`: updated a comment that still cited the shared `"ship"` texture as the reason `MainWorld.destroy()` skips `texture`/`baseTexture` cleanup; it's now the per-type unit textures that the next `MainWorld` reuses.

## Kept — not actually dead

- **`isRenderable()` duck-type guard in `shared/game_world.ts`.** All six real main-game unit types (Hero, Wanderer, PackLeader, PackFollower, Bandit, BanditCaptain) now apply the `Renderable` mixin — but `main/harness/interaction_harness.ts`'s `HarnessTarget` (a plain `Damageable(Unit)` stand-in used by several Playwright interaction specs: `auto-attack-choice`, `auto-attack-move`, `auto-attack-highlight-click-lock`) does **not**. Rather than resurrect a `"ship"` fallback texture for it, non-Renderable units now render with just the colored hex background — no icon layer, no fallback texture needed.
- **The intro scene (`game/intro/**`) and its assets** — `assets/all/ship.png`, `assets/sprites/intro-0.png`/`.json`, `assets/intro/files.txt` — untouched. `game/intro/preload.ts` loads `intro-0` completely independently, for the intro scene's own real `Ship` unit (`game/intro/units/index.ts`: `Renderable(Movable(Unit, 100), "ship")`), which already sets its own `textureName` via `Renderable` and never depended on `main/preload.ts`'s redundant loading of the same atlas.

## Verification
- `npx tsc --noEmit -p .` — clean
- `npx astro check` — 0 errors, 0 warnings
- `npx vitest run` — 395 tests pass
- `npx playwright test` — 7/7 interaction specs pass, including the ones spawning `HarnessTarget`
- Smoke-tested the intro scene on `/` with a throwaway Playwright script (synthetic click at the viewport center so `IntroWorld.setup()` resolves a real tile): no new console warnings/errors vs. master. One pre-existing warning burst (`Asset id hero/wolf/wanderer/ship was not found in the Cache`, from a startup race between initial Spawn dispatch and asset-load completion) reproduces identically on master with these changes stashed out, confirming it's an unrelated pre-existing issue, not a regression from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)