### PR TITLE
Fix unit sprites never resolving (PixiJS Cache miss on every spawn)

### DIFF
--- a/apps/home/src/game/intro/game_world.ts
+++ b/apps/home/src/game/intro/game_world.ts
@@ -18,7 +18,11 @@ export class IntroWorld extends GameWorld {
     protected events: EventSystem,
     protected sheet: Spritesheet
   ) {
-    super(board, events, sheet);
+    // The intro's single atlas (intro-0) carries both its terrain (water)
+    // and its "ship" unit frame, so it doubles as its own units sheet — see
+    // shared/game_world.ts's constructor comment for why Spawn needs one
+    // passed directly rather than relying on Texture.from(name).
+    super(board, events, sheet, sheet);
     this.emitter = new EventEmitter();
     this.scenario = new Scenario(this.game);
   }

--- a/apps/home/src/game/main/game_world.ts
+++ b/apps/home/src/game/main/game_world.ts
@@ -83,13 +83,14 @@ export class MainWorld extends GameWorld {
     protected board: Board,
     protected events: EventSystem,
     protected sheet: Spritesheet,
+    protected unitsSheet: Spritesheet,
     // Injectable so callers other than the real site (e.g. the interaction
     // test harness, docs/adr/0001) can boot MainWorld against a minimal
     // definition/script instead of always mounting Stage 1 in full.
     definition: StageDefinition = createStage1Definition(),
     narrativeScript: NarrativeScript = createStage1Narrative(definition.player.id, "wanderer")
   ) {
-    super(board, events, sheet);
+    super(board, events, sheet, unitsSheet);
 
     this.narrative = new NarrativeEngine(narrativeScript);
     this.scenario = new Scenario(this.game, definition);

--- a/apps/home/src/game/main/index.ts
+++ b/apps/home/src/game/main/index.ts
@@ -4,7 +4,7 @@ import { preload } from "./preload";
 import { StageManager } from "./stage_manager";
 
 export async function create(app: Application) {
-  const { sheet } = await preload();
+  const { sheet, unitsSheet } = await preload();
 
-  return new StageManager(app.renderer.events, sheet);
+  return new StageManager(app.renderer.events, sheet, unitsSheet);
 }

--- a/apps/home/src/game/main/preload.ts
+++ b/apps/home/src/game/main/preload.ts
@@ -10,12 +10,15 @@ export async function preload() {
   const sheet = new Spritesheet(boardTexture.source, data);
   await sheet.parse();
 
-  // Load the dedicated units sheet (gh #192) to make its textures (hero,
-  // wanderer, wolf, bandit, banditCaptain) available globally the same way —
-  // game_world.ts's Spawn handling looks them up via Texture.from(name).
+  // Dedicated units sheet (gh #192: hero, wanderer, wolf, bandit,
+  // banditCaptain). Returned alongside `sheet` and read directly via
+  // `unitsSheet.textures[name]` — not through Texture.from(name)'s global
+  // Cache, which never gets populated for a manually-constructed/parsed
+  // Spritesheet like this one (that only happens via the real
+  // Assets.load(".json") pipeline).
   const unitsTexture = await Assets.load(unitsImage.src);
   const unitsSheet = new Spritesheet(unitsTexture.source, unitsData);
   await unitsSheet.parse();
 
-  return { sheet };
+  return { sheet, unitsSheet };
 }

--- a/apps/home/src/game/main/stage_manager.ts
+++ b/apps/home/src/game/main/stage_manager.ts
@@ -29,7 +29,8 @@ export class StageManager extends Container {
 
   constructor(
     protected events: EventSystem,
-    protected sheet: Spritesheet
+    protected sheet: Spritesheet,
+    protected unitsSheet: Spritesheet
   ) {
     super();
     this.mainWorld = this.mountStage(this.currentIndex);
@@ -51,6 +52,7 @@ export class StageManager extends Container {
       entry.board,
       this.events,
       this.sheet,
+      this.unitsSheet,
       definition,
       entry.createNarrative(definition.player.id, "wanderer")
     );

--- a/apps/home/src/game/shared/game_world.ts
+++ b/apps/home/src/game/shared/game_world.ts
@@ -5,7 +5,6 @@ import {
   type DestroyOptions,
   Sprite,
   Spritesheet,
-  Texture,
   type EventSystem,
   ColorMatrixFilter,
 } from "pixi.js";
@@ -78,7 +77,16 @@ export class GameWorld extends Container {
   constructor(
     protected board: Board,
     protected events: EventSystem,
-    protected sheet: Spritesheet
+    protected sheet: Spritesheet,
+    // Units' own atlas (gh #192). Passed and read directly — like `sheet` is
+    // for terrain — rather than relying on Texture.from(name)'s global Cache
+    // lookup: that lookup only ever resolves for Spritesheets registered
+    // through the real Assets.load(".json") pipeline (its CacheParser
+    // extension is what expands one cache entry into one per frame name).
+    // preload.ts manually constructs `new Spritesheet(texture, data)` +
+    // `.parse()`, which never touches Cache.set() at all, so Texture.from()
+    // here always warned "not found in the Cache" and rendered no icon.
+    protected unitsSheet: Spritesheet
   ) {
     super();
     this.game = new Game(board);
@@ -137,7 +145,7 @@ export class GameWorld extends Container {
           // there's no per-type icon to fall back to since gh #194 removed
           // the old shared "ship" placeholder.
           if (isRenderable(action.unit)) {
-            const unitTexture = Texture.from(action.unit.textureName);
+            const unitTexture = this.unitsSheet.textures[action.unit.textureName];
             const unitSprite = new Tile(unitTexture, action.position);
             unitContainer.addChild(unitSprite);
           }

--- a/apps/home/src/pages/interaction-harness.astro
+++ b/apps/home/src/pages/interaction-harness.astro
@@ -56,7 +56,7 @@ if (!import.meta.env.DEV) {
           TWEEN.update();
         });
 
-        const { sheet } = await preload();
+        const { sheet, unitsSheet } = await preload();
 
         // Default stays no narrative script — nothing should block input in
         // the harness (docs/adr/0001). ?narrative=1 opts a specific test into
@@ -81,6 +81,7 @@ if (!import.meta.env.DEV) {
           createHarnessBoard(),
           app.renderer.events,
           sheet,
+          unitsSheet,
           definition,
           narrativeScript
         );


### PR DESCRIPTION
## Summary

Fixes a live production bug reported via browser console: every unit spawn
logged repeated PixiJS warnings —

```
[Assets] Asset id hero was not found in the Cache
[Assets] Asset id wolf was not found in the Cache
[Assets] Asset id wanderer was not found in the Cache
```

— meaning every unit rendered with **no icon at all**, just its owner-color
hex background.

## Root cause

`main/preload.ts` loads the units atlas by manually constructing
`new Spritesheet(texture, data)` and calling `.parse()`. That populates the
Spritesheet instance's own `.textures` dict, but **never touches PixiJS's
global `Cache`** — `Cache.set()` only expands a Spritesheet into one entry
per frame name via a registered `CacheParser` extension, and that expansion
is wired into the real `Assets.load()` pipeline (loading a `.json`
spritesheet asset end-to-end), not into manual construction.
`Texture.from("hero")` in `game_world.ts`'s Spawn handling was therefore
always going to warn and return nothing — not a race condition, the lookup
could never have succeeded.

Terrain tiles never hit this because they've always read
`sheet.textures[name]` directly off the local Spritesheet instance passed
into `GameWorld`'s constructor (never touching `Texture.from`/the global
Cache at all).

## Fix

Unit textures now follow the same proven pattern terrain already uses:
`preload()` returns `unitsSheet` alongside `sheet`, threaded through
`main/index.ts` → `StageManager` → `MainWorld` → the shared `GameWorld`
base class (a constructor param, mirroring `sheet`), and the Spawn case
reads `this.unitsSheet.textures[name]` instead of the never-populated
global Cache. `IntroWorld` passes its own single atlas as both `sheet` and
`unitsSheet`, since `intro-0` already carries both its terrain and its
"ship" unit frame in one atlas. `interaction-harness.astro` (which spawns a
real `Hero` through the same `MainWorld` constructor) updated to match.

## Verification

- `tsc --noEmit`, `astro check`, `vitest run` (395/395) all clean.
- Manually reproduced against a real production build (`astro build` +
  `astro preview`) *before* the fix — confirmed the exact same "not found
  in Cache" warnings firing on a real browser session.
- After the fix, a 60-second real-browser session through the intro (which
  spawns a `Ship` unit via the identical Spawn code path) produced **zero**
  console warnings/errors, and the ship rendered correctly on screen
  instead of blank.
- Could not drive the Playwright interaction suite locally in this sandbox
  (`astro dev` daemonizes itself under a non-TTY shell here, unrelated to
  this change — same limitation hit on a prior PR in this session); CI will
  verify it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)