### PR TITLE
Fix close() destroying shared, Assets-managed textures on intro skip

### DIFF
--- a/apps/home/src/game/game_loader.ts
+++ b/apps/home/src/game/game_loader.ts
@@ -77,10 +77,20 @@ function close() {
   app.canvas.style.display = "none";
   // app.loader.reset();
 
+  // No `texture`/`textureSource` here: board/units/intro sprites read from
+  // the shared, Assets-managed atlases `preload()` loads once per page
+  // session (aliased "board1"/"units"/"intro") — destroying a
+  // TextureSource that way (rather than via Assets.unload()) leaves
+  // Assets' own cache still pointing at the now-destroyed GPU resource, so
+  // every future preload() on this page (reinitialize() below always
+  // triggers one) resolves to a broken texture instead of reloading it.
+  // That's a permanent, session-wide break, not just this viewport's —
+  // matches the same reasoning main/stage_manager.ts's teardown already
+  // documents for the exact same class of shared atlas.
   while (app.stage.children[0]) {
     const child = app.stage.children[0] as GameViewport;
     app.stage.removeChild(child);
-    child.destroy({ children: true, texture: true, textureSource: true });
+    child.destroy({ children: true });
   }
 
   reinitialize();


### PR DESCRIPTION
## Summary

Follow-up to #213. Reported as "the game doesn't load" — reproduced
against a real production build.

Clicking anywhere on the board a second time after the initial
ship-placement click (\`IntroWorld.teardown()\`'s "click again to skip the
intro" affordance) fires the intro's \`"exit"\` event, handled by
\`game_loader.ts\`'s \`close()\`:

\`\`\`ts
child.destroy({ children: true, texture: true, textureSource: true });
\`\`\`

called on every current \`app.stage\` child. That destroys the underlying
GPU \`TextureSource\` for whichever atlas that child's sprites happen to
read from — \`board1-0\`, \`units-0\`, or \`intro-0\`, all loaded **once per
page session** and reused by every subsequent \`preload()\` call. Destroying
a \`TextureSource\` this way (instead of via \`Assets.unload()\`, per PixiJS's
own warning: *"A TextureSource managed by Assets was destroyed instead of
unloaded!"*) leaves \`Assets\`' cache still pointing at the now-destroyed
resource — so \`close()\`'s own \`reinitialize()\` (which always re-triggers a
fresh \`preload()\`) resolves every subsequent texture lookup to a broken
resource for the **rest of the page session**, not just this one instance.

This is the same class of bug \`main/stage_manager.ts\`'s teardown already
documents avoiding, for the identical reason (shared atlas reused by the
next instance).

## Fix

Drop \`texture\`/\`textureSource\` from the destroy call, matching the safe
pattern already used by the normal (non-skip) completion path in this same
file (\`viewport.destroy()\`, no options) and by \`stage_manager.ts\`'s
stage-to-stage teardown.

## Verification

Reproduced against a real production build (\`astro build\` + \`astro
preview\`) with Playwright:
- **Before the fix**: clicking the board twice reliably produced the
  "TextureSource... destroyed instead of unloaded" warning.
- **After the fix**: the same double-click sequence produces zero console
  warnings/errors, and the canvas continues rendering normally afterward.
- \`tsc --noEmit\` and \`vitest run\` (395/395) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)