### PR TITLE
Add regression tests for #213 (Cache-miss unit icons) and #214 (close() texture destruction)

### DIFF
--- a/apps/home/interaction/intro-skip-preserves-shared-textures.spec.ts
+++ b/apps/home/interaction/intro-skip-preserves-shared-textures.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+
+// gh #214: clicking the board a second time during the intro (IntroWorld's
+// "click again to skip" affordance, registered by teardown()) fires the
+// intro's "exit" event, handled by game_loader.ts's close(). close() used to
+// destroy every current app.stage child with
+// `{ texture: true, textureSource: true }` — which destroys the underlying
+// GPU TextureSource for whichever atlas that child's sprites read from
+// (board1-0/units-0/intro-0), all loaded once per page session and reused by
+// every later preload() call. PixiJS's own Assets cache doesn't know the
+// resource is gone, so every subsequent texture lookup silently resolves to
+// a broken resource for the rest of the page — not just this one instance.
+// PixiJS warns exactly this: "A TextureSource managed by Assets was
+// destroyed instead of unloaded! Use Assets.unload() instead of destroying
+// the TextureSource." This drives the real skip-intro gesture (not the
+// interaction harness, which deliberately bypasses the intro entirely) and
+// asserts that warning never fires.
+test("clicking the board again to skip the intro doesn't destroy the shared atlas textures", async ({
+  page,
+}) => {
+  const textureDestroyedWarnings: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "warning" && /destroyed instead of unloaded/.test(msg.text())) {
+      textureDestroyedWarnings.push(msg.text());
+    }
+  });
+
+  await page.goto("/");
+  await page.waitForSelector("#warriors");
+
+  // Click at a fixed point (not Playwright's default "center of #warriors",
+  // so the exact coordinates are known) — game_loader.ts's initGame()
+  // resolves with this point, and IntroWorld.setup() uses it to look up a
+  // tile at that same screen position, starting the ship's placement
+  // animation there and registering teardown()'s "clicked" listener.
+  const box = (await page.locator("#warriors").boundingBox())!;
+  const clickPoint = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  await page.mouse.click(clickPoint.x, clickPoint.y);
+
+  await page.waitForFunction(() => {
+    const canvas = document.querySelector("canvas");
+    return !!canvas && getComputedStyle(canvas).display !== "none";
+  });
+
+  // intro/index.ts's create() shows the canvas immediately but defers
+  // world.setup() (and, inside it, the teardown() call that registers this
+  // "clicked" skip listener) by 100ms — a click landing in that window is a
+  // silent no-op (no listener yet). Give it a comfortable margin.
+  await page.waitForTimeout(500);
+
+  // #warriors never gets hidden/removed (main/preload.ts only swaps the
+  // #game div for the canvas), so it's still sitting at the same screen
+  // position underneath the now-visible canvas (z-index 2) — clicking the
+  // exact same point again lands back on a tile we already know is real,
+  // firing teardown()'s "clicked" listener -> the skip -> close() path.
+  await page.mouse.click(clickPoint.x, clickPoint.y);
+
+  // close()'s reinitialize() re-shows the pre-game state, waiting for a
+  // fresh #warriors click — give it time to actually run.
+  await expect
+    .poll(() => page.evaluate(() => document.querySelector("canvas")?.style.display))
+    .toBe("none");
+
+  expect(textureDestroyedWarnings).toEqual([]);
+});

--- a/apps/home/interaction/unit-icon-texture-resolves.spec.ts
+++ b/apps/home/interaction/unit-icon-texture-resolves.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+// gh #213: main/preload.ts used to load the units atlas by manually
+// constructing `new Spritesheet(texture, data)` + `.parse()`, then relying
+// on `Texture.from(name)` in game_world.ts's Spawn handling to find "hero"/
+// "wolf"/etc. That never worked — PixiJS's Cache only gets a per-frame entry
+// per name when a Spritesheet is loaded through the real `Assets.load(".json")`
+// pipeline (its CacheParser expands one Cache entry into one per frame); a
+// manually-constructed-and-parsed Spritesheet never touches Cache.set() at
+// all. So every unit rendered with no icon, and PixiJS logged a
+// "[Assets] Asset id <name> was not found in the Cache" warning on every
+// single spawn. This drives a real spawn (the harness's Hero) and asserts
+// that warning never fires — it would have fired on every run before the fix.
+test("spawning a unit resolves its icon texture without a Cache-miss warning", async ({
+  page,
+}) => {
+  const cacheMissWarnings: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "warning" && /was not found in the Cache/.test(msg.text())) {
+      cacheMissWarnings.push(msg.text());
+    }
+  });
+
+  await page.goto("/interaction-harness");
+
+  // Confirms the Hero has actually been spawned (not just that preload()
+  // resolved) before asserting no warning fired for it.
+  await expect
+    .poll(() => page.evaluate(() => window.__test?.getUnitSectionByOwner("human")))
+    .toBe("harness_start");
+
+  expect(cacheMissWarnings).toEqual([]);
+});


### PR DESCRIPTION
## Summary

Both #213 and #214 shipped to production with no test coverage that
would have caught them — vitest can't reach real PixiJS rendering (no
jsdom/canvas environment configured here), and neither existing
interaction test touched unit-icon texture resolution or the intro's
skip gesture.

- **\`unit-icon-texture-resolves.spec.ts\`**: spawns the harness's real
  Hero and asserts no \`"[Assets] Asset id <name> was not found in the
  Cache"\` console warning fires — #213's exact symptom.
- **\`intro-skip-preserves-shared-textures.spec.ts\`**: drives the real
  page (not the harness, which deliberately bypasses the intro) through
  the actual "click the board twice to skip the intro" gesture and
  asserts no \`"TextureSource... destroyed instead of unloaded"\` warning
  fires — #214's exact symptom.

## Verification

Confirmed each test actually catches its bug, not just passes
coincidentally: temporarily reverted the corresponding fix commit's
files locally, ran the new test, confirmed it failed with the exact
original warning message, then restored the fix and confirmed green
again for both.

Also ran the full suite together (\`tsc\`, \`vitest\`, \`playwright test\`) —
all clean, 9/9 interaction tests passing.

## Aside

While debugging test flakiness in this sandbox, found that Astro v7's
\`astro dev\` auto-detects "AI agent" environments (via the \`am-i-vibing\`
package) and silently backgrounds itself, which breaks Playwright's
\`webServer\` integration locally. \`ASTRO_DEV_BACKGROUND=1\` overrides that
back to foreground mode. Not wired into any script — CI's own runner
doesn't hit this — just noting it in case it comes up again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)