### PR TITLE
Fix intro darkness and main-game camera cutoff

### DIFF
--- a/apps/home/src/game/core/grid/get_grid_bounding_box.test.ts
+++ b/apps/home/src/game/core/grid/get_grid_bounding_box.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import { createGrid, TILE_SIZE } from "./create_grid";
+import { getGridBoundingBox } from "./get_grid_bounding_box";
+import { Terrain, type Board } from "../board";
+
+function makeBoard(cols: number, rows: number): Board {
+  return {
+    rows,
+    cols,
+    tiles: Array.from({ length: cols }, (_, x) =>
+      Array.from({ length: rows }, (_, y) => ({
+        x,
+        y,
+        type: Terrain.WATER,
+        textureName: "grass",
+        sectionName: "none",
+      }))
+    ).flat(),
+  };
+}
+
+describe("getGridBoundingBox", () => {
+  test("a single hex's bounding box is its own size, not inflated by its position", () => {
+    const grid = createGrid(makeBoard(1, 1));
+    const { worldWidth, worldHeight } = getGridBoundingBox(grid);
+
+    // A single flat-top hex sits at the origin: its furthest corner is half
+    // its own width/height away, regardless of TILE_SIZE.
+    expect(worldWidth).toBeCloseTo(TILE_SIZE, 0);
+    expect(worldHeight).toBeCloseTo((TILE_SIZE * Math.sqrt(3)) / 2, 0);
+  });
+
+  test("bounding box tracks a multi-hex grid's real extent, not roughly double it", () => {
+    // Matches board1.json's real size (10 cols x 8 rows) — this is the exact
+    // shape that surfaced the bug: MainWorld's camera centering
+    // (main/game_world.ts) used to aim at a point ~2x past the board's real
+    // center, because this function added a hex's own absolute position on
+    // top of its already-absolute corner coordinates (honeycomb-grid v4's
+    // `corners` getter returns world-space points, not offsets relative to
+    // the hex — see this function's own comment for the full explanation).
+    const grid = createGrid(makeBoard(10, 8));
+    const { worldWidth, worldHeight } = getGridBoundingBox(grid);
+
+    const positions = grid.toArray().map((h) => h.toPoint());
+    const maxTileX = Math.max(...positions.map((p) => p.x));
+    const maxTileY = Math.max(...positions.map((p) => p.y));
+
+    // The bounding box is a modest hex-sized margin beyond the furthest
+    // tile's own center — never anywhere near double it. A flat-top hex's
+    // furthest corner sits exactly TILE_SIZE past its own center, so this
+    // margin is a tight bound, not a loose one.
+    expect(worldWidth).toBeGreaterThan(maxTileX);
+    expect(worldWidth).toBeLessThanOrEqual(maxTileX + TILE_SIZE);
+    expect(worldHeight).toBeGreaterThan(maxTileY);
+    expect(worldHeight).toBeLessThanOrEqual(maxTileY + TILE_SIZE);
+  });
+});

--- a/apps/home/src/game/core/grid/get_grid_bounding_box.ts
+++ b/apps/home/src/game/core/grid/get_grid_bounding_box.ts
@@ -11,20 +11,23 @@ export function getGridBoundingBox(grid: Grid<GameTileHex>): WorldDimensions {
 
   if (!lastHex) throw new Error("No hex found in grid");
 
-  const lastPoint = lastHex.toPoint();
+  // honeycomb-grid v4's `corners` getter already returns absolute
+  // (world-space) points — each one is the hex's own x/y plus a corner
+  // offset (see the library's flat/pointy corner formulas) — not points
+  // relative to the hex's origin the way v1's did. Adding `lastHex.toPoint()`
+  // on top of that (as the v1-era version of this function did) double-counts
+  // the hex's position, inflating the computed bounding box to roughly double
+  // the grid's real size for any hex far from the origin — which is exactly
+  // what silently broke MainWorld's camera centering (see main/game_world.ts).
   const lastCorners = lastHex.corners;
-  const worldWidth =
-    lastPoint.x +
-    Math.max.apply(
-      Math,
-      lastCorners.map((c) => c.x)
-    );
-  const worldHeight =
-    lastPoint.y +
-    Math.max.apply(
-      Math,
-      lastCorners.map((c) => c.y)
-    );
+  const worldWidth = Math.max.apply(
+    Math,
+    lastCorners.map((c) => c.x)
+  );
+  const worldHeight = Math.max.apply(
+    Math,
+    lastCorners.map((c) => c.y)
+  );
 
   return { worldWidth, worldHeight };
 }

--- a/apps/home/src/game/intro/game_world.ts
+++ b/apps/home/src/game/intro/game_world.ts
@@ -76,6 +76,15 @@ export class IntroWorld extends GameWorld {
     return sprite;
   }
 
+  // Fog-of-war (base GameWorld's renderFog/updateFog) is a real-gameplay
+  // mechanic keyed on a unit's sight range — the intro's Ship has none (it's
+  // a scripted cinematic, not a player unit with hidden information to
+  // reveal), so every fog tile would otherwise stay permanently visible at
+  // its full 85% black opacity for the whole scene. Skip building fog tiles
+  // at all; updateFog() is then naturally a no-op against an empty
+  // fogTiles map.
+  protected renderFog() {}
+
   private fadeOut() {
     let state = { alpha: 1 };
     return new TWEEN.Tween(state, true)

--- a/apps/home/src/game/main/game_world.ts
+++ b/apps/home/src/game/main/game_world.ts
@@ -92,6 +92,14 @@ export class MainWorld extends GameWorld {
   ) {
     super(board, events, sheet, unitsSheet);
 
+    // Center the camera on the board. Without this, pixi-viewport's default
+    // camera position shows the board's origin corner rather than fitting
+    // its content in view — there's no other moveCenter()/fit() call
+    // anywhere in this codebase, so most of the board renders off-screen
+    // above/right of what's visible.
+    const { worldWidth, worldHeight } = this.game.world.getState();
+    this.viewport.moveCenter(worldWidth / 2, worldHeight / 2);
+
     this.narrative = new NarrativeEngine(narrativeScript);
     this.scenario = new Scenario(this.game, definition);
 


### PR DESCRIPTION
## Summary

Reported: *"overlay disappeared from game but intro is too dark, game is
rendered too high and is cut off, fix it."* Reproduced both against a real
production build with Playwright screenshots and fixed at the root cause.

### 1. Main game camera showing the board's corner, not its content (`3d9f8cb`)

`getGridBoundingBox()` computed `worldWidth`/`worldHeight` at roughly
**double** the board's real extent — a leftover from the honeycomb-grid
v1→v4 migration (`ae995ab`). v4's `corners` getter already returns
absolute (world-space) points, but this function still added the hex's
own position on top, double-counting it. For board1 (10×8 tiles) this
inflated a true ~700×625 bounding box to a reported 1400×1342.

That inflated size was the *only* thing the camera had to go on — this
codebase has no `moveCenter()`/`fit()` call anywhere. Combined with
pixi-viewport's default camera position, the result was: only the board's
origin corner ever visible, the rest of the screen showing empty
(over-reported) "world" space.

Fixed the double-counting, added a test (this function had none — how the
~2x inflation went unnoticed), and added an explicit `moveCenter()` call
on `MainWorld` construction so the corrected bounding box actually
translates into the board being centered on screen.

### 2. Intro permanently pitch-dark under full fog-of-war (`5c151ab`)

Fog-of-war reveal is keyed on a unit's sight range. The intro's `Ship`
unit has no `Sightful` mixin, so the reducer never reveals *any* tiles for
it — every fog tile stayed at its full 85%-opaque black for the entire
scene. Fog-of-war is a real-gameplay mechanic that doesn't apply to the
intro's scripted cinematic at all, so `IntroWorld` now skips it entirely
(`renderFog()` overridden to a no-op) rather than awkwardly making the
Ship "see."

## Verification

Both reproduced and fixed against a real production build
(`astro build && astro preview`) with Playwright screenshots:
- **Camera**: before, only a small top-left sliver of the board was
  visible; after, the full board is centered and visible.
- **Intro**: before, near-black with barely any visible color; after, the
  ocean renders at its real brightness with the ship clearly visible.

`tsc`, `astro check`, `vitest` (397/397, incl. 2 new tests for the
bounding-box fix — verified to fail against the old buggy implementation
before confirming they pass against the fix), and the full Playwright
interaction suite (9/9) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)