### PR TITLE
Fix MainWorld camera still clipping the board's top after PR #217

### DIFF
--- a/apps/home/src/game/core/conditions/index.test.ts
+++ b/apps/home/src/game/core/conditions/index.test.ts
@@ -55,6 +55,8 @@ function makeState(tiles: GameTileHex[], units: UnitPosition[]): State {
     outcome: null,
     worldWidth: 300,
     worldHeight: 300,
+    minX: 0,
+    minY: 0,
     cols: 3,
     rows: 3,
   };

--- a/apps/home/src/game/core/grid/get_grid_bounding_box.test.ts
+++ b/apps/home/src/game/core/grid/get_grid_bounding_box.test.ts
@@ -54,4 +54,21 @@ describe("getGridBoundingBox", () => {
     expect(worldHeight).toBeGreaterThan(maxTileY);
     expect(worldHeight).toBeLessThanOrEqual(maxTileY + TILE_SIZE);
   });
+
+  test("minX/minY report the grid's true top-left corner, not the origin", () => {
+    // The col/row 0 hex's own corners reach half a tile-width/height above
+    // and left of its center, so the grid's real top-left corner sits at
+    // negative X/Y — not [0, 0]. MainWorld's camera centering (main/game_world.ts)
+    // used to assume [0, 0] was the top-left corner, aiming the camera past
+    // the board's true center and clipping the top row off-screen.
+    const grid = createGrid(makeBoard(10, 8));
+    const { minX, minY } = getGridBoundingBox(grid);
+
+    expect(minX).toBeLessThan(0);
+    expect(minY).toBeLessThan(0);
+    // A flat-top hex's leftmost/topmost corner sits exactly TILE_SIZE (its
+    // own half-width) / half its height past its own center — never further.
+    expect(minX).toBeGreaterThanOrEqual(-TILE_SIZE);
+    expect(minY).toBeGreaterThanOrEqual(-(TILE_SIZE * Math.sqrt(3)) / 2);
+  });
 });

--- a/apps/home/src/game/core/grid/get_grid_bounding_box.ts
+++ b/apps/home/src/game/core/grid/get_grid_bounding_box.ts
@@ -4,30 +4,46 @@ import type { GameTileHex } from "../board";
 interface WorldDimensions {
   worldWidth: number;
   worldHeight: number;
+  // Flat-top hexes at col/row 0 extend into negative X/Y — their own
+  // corners reach half a tile-width/height above and left of their
+  // center — so [0, 0] is NOT the grid's true top-left corner. Callers
+  // that need the grid's actual visible extent (e.g. centering the
+  // camera on it) must offset by these, not assume the box starts at the
+  // origin the way worldWidth/worldHeight (measured from x=0/y=0, matching
+  // the clamp plugin's own origin-relative bounds) do.
+  minX: number;
+  minY: number;
 }
 
 export function getGridBoundingBox(grid: Grid<GameTileHex>): WorldDimensions {
-  const lastHex = grid.toArray()[grid.size - 1];
-
-  if (!lastHex) throw new Error("No hex found in grid");
+  if (grid.size === 0) throw new Error("No hex found in grid");
 
   // honeycomb-grid v4's `corners` getter already returns absolute
   // (world-space) points — each one is the hex's own x/y plus a corner
   // offset (see the library's flat/pointy corner formulas) — not points
-  // relative to the hex's origin the way v1's did. Adding `lastHex.toPoint()`
-  // on top of that (as the v1-era version of this function did) double-counts
-  // the hex's position, inflating the computed bounding box to roughly double
+  // relative to the hex's origin the way v1's did. Adding a hex's own
+  // position on top of that (as the v1-era version of this function did)
+  // double-counts it, inflating the computed bounding box to roughly double
   // the grid's real size for any hex far from the origin — which is exactly
   // what silently broke MainWorld's camera centering (see main/game_world.ts).
-  const lastCorners = lastHex.corners;
-  const worldWidth = Math.max.apply(
-    Math,
-    lastCorners.map((c) => c.x)
-  );
-  const worldHeight = Math.max.apply(
-    Math,
-    lastCorners.map((c) => c.y)
-  );
+  //
+  // The furthest corners aren't necessarily on the first/last hex (column
+  // offsetting in flat-top layouts can push another hex's corner further
+  // out), so every hex's corners are scanned rather than assuming an
+  // extreme hex.
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
 
-  return { worldWidth, worldHeight };
+  for (const hex of grid) {
+    for (const corner of hex.corners) {
+      if (corner.x < minX) minX = corner.x;
+      if (corner.y < minY) minY = corner.y;
+      if (corner.x > maxX) maxX = corner.x;
+      if (corner.y > maxY) maxY = corner.y;
+    }
+  }
+
+  return { worldWidth: maxX, worldHeight: maxY, minX, minY };
 }

--- a/apps/home/src/game/core/narrative/index.test.ts
+++ b/apps/home/src/game/core/narrative/index.test.ts
@@ -64,6 +64,8 @@ function makeState(
     outcome: null,
     worldWidth: 500,
     worldHeight: 500,
+    minX: 0,
+    minY: 0,
     cols: 5,
     rows: 5,
   };

--- a/apps/home/src/game/core/player_store.test.ts
+++ b/apps/home/src/game/core/player_store.test.ts
@@ -24,6 +24,8 @@ function makeStore() {
     outcome: null,
     worldWidth: 500,
     worldHeight: 500,
+    minX: 0,
+    minY: 0,
     cols: 10,
     rows: 10,
   };

--- a/apps/home/src/game/core/reducers/index.test.ts
+++ b/apps/home/src/game/core/reducers/index.test.ts
@@ -24,6 +24,8 @@ function makeState(overrides: Partial<State> = {}): State {
     outcome: null,
     worldWidth: 300,
     worldHeight: 200,
+    minX: 0,
+    minY: 0,
     cols: 5,
     rows: 5,
     ...overrides,

--- a/apps/home/src/game/core/world.ts
+++ b/apps/home/src/game/core/world.ts
@@ -20,6 +20,13 @@ export interface State {
   turn: number;
   worldWidth: number;
   worldHeight: number;
+  // Grid's true top-left corner (see getGridBoundingBox) — [0, 0] is NOT it
+  // for flat-top hexes. shared/game_world.ts's worldContainer shifts all
+  // rendering by (-minX, -minY) so the board actually spans [0, worldWidth]
+  // x [0, worldHeight], matching what pixi-viewport's clamp/moveCenter
+  // assume.
+  minX: number;
+  minY: number;
   cols: number;
   rows: number;
   tiles: Array<GameTileHex>;
@@ -45,7 +52,7 @@ export class World {
       return acc;
     }, []);
 
-    const { worldWidth, worldHeight } = getGridBoundingBox(grid);
+    const { worldWidth, worldHeight, minX, minY } = getGridBoundingBox(grid);
     const { cols, rows } = getGridSize(grid);
 
     // @ts-ignore
@@ -54,6 +61,8 @@ export class World {
       tiles,
       worldWidth,
       worldHeight,
+      minX,
+      minY,
       cols,
       rows,
     });

--- a/apps/home/src/game/editor/reducer.ts
+++ b/apps/home/src/game/editor/reducer.ts
@@ -14,12 +14,14 @@ function stateFromBoard(board: Board) {
     return acc;
   }, [] as GridElement<typeof grid>[]);
 
-  const { worldWidth, worldHeight } = getGridBoundingBox(grid);
+  const { worldWidth, worldHeight, minX, minY } = getGridBoundingBox(grid);
 
   return {
     tiles,
     worldWidth,
     worldHeight,
+    minX,
+    minY,
     // `board.rows`/`board.cols` were never round-tripped into State here —
     // harmless while nothing read state.rows/state.cols back (the old dead
     // EditorWorld tracked its own rows/columns separately in its GUI data),

--- a/apps/home/src/game/intro/game_world.ts
+++ b/apps/home/src/game/intro/game_world.ts
@@ -28,12 +28,14 @@ export class IntroWorld extends GameWorld {
   }
 
   setup(point: Point) {
-    // Convert screen coordinates to viewport-relative coordinates
-    const localPoint = this.viewport.toLocal(new Point(point.x, point.y));
+    // Convert screen coordinates to worldContainer-relative coordinates —
+    // tiles live in worldContainer's (shifted) frame, not viewport's own
+    // (see shared/game_world.ts's constructor comment).
+    const localPoint = this.worldContainer.toLocal(new Point(point.x, point.y));
 
     // Find the tile that contains this point
     let clickedTile: Tileable | null = null;
-    for (const tile of this.viewport.children) {
+    for (const tile of this.worldContainer.children) {
       if (tile instanceof Tileable) {
         const bounds = tile.getBounds();
         if (bounds.containsPoint(localPoint.x, localPoint.y)) {

--- a/apps/home/src/game/main/game_world.ts
+++ b/apps/home/src/game/main/game_world.ts
@@ -96,15 +96,17 @@ export class MainWorld extends GameWorld {
     // camera position shows the board's origin corner rather than fitting
     // its content in view — there's no other moveCenter()/fit() call
     // anywhere in this codebase, so most of the board renders off-screen
-    // above/right of what's visible.
-    const { worldWidth, worldHeight } = this.game.world.getState();
-    this.viewport.moveCenter(worldWidth / 2, worldHeight / 2);
+    // above/right of what's visible. Simple half-width/half-height works
+    // here (unlike a raw state.worldWidth/2) because worldContainer (see
+    // shared/game_world.ts) already shifted the board so it truly spans
+    // [0, viewport.worldWidth] x [0, viewport.worldHeight].
+    this.viewport.moveCenter(this.viewport.worldWidth / 2, this.viewport.worldHeight / 2);
 
     this.narrative = new NarrativeEngine(narrativeScript);
     this.scenario = new Scenario(this.game, definition);
 
     // Highlights render above the board terrain/fog but move with the viewport.
-    this.viewport.addChild(this.highlightContainer);
+    this.worldContainer.addChild(this.highlightContainer);
     this.createEndTurnButton();
 
     // Board clicks are resolved here, not via per-tile pointertap listeners:
@@ -113,8 +115,13 @@ export class MainWorld extends GameWorld {
     // container's own hitArea as an override that its children are never
     // checked against — no tile or unit sprite can ever receive a pointer
     // event underneath it. "clicked" is pixi-viewport's own click-vs-drag
-    // disambiguation, carrying the world-space point to resolve manually.
-    this.viewport.on("clicked", (e) => this.handleViewportClicked(e.world));
+    // disambiguation, carrying the point in the viewport's own (unshifted)
+    // frame — converted into worldContainer's frame (where tile/hex
+    // coordinates actually live) before it's resolved to a hex below.
+    this.viewport.on("clicked", (e) => {
+      const local = this.worldContainer.toLocal(e.world, this.viewport);
+      this.handleViewportClicked(local);
+    });
 
     this.scenario.emitter.on("playerTurn", (data: { units: UnitPosition[] }) => {
       this.isPlayerTurn = true;

--- a/apps/home/src/game/main/stage_editor/editor_world.ts
+++ b/apps/home/src/game/main/stage_editor/editor_world.ts
@@ -112,6 +112,8 @@ export class StageEditorWorld extends Container {
       outcome: null,
       worldWidth: 1000,
       worldHeight: 1000,
+      minX: 0,
+      minY: 0,
       cols: 0,
       rows: 0,
     });

--- a/apps/home/src/game/shared/game_world.ts
+++ b/apps/home/src/game/shared/game_world.ts
@@ -73,6 +73,10 @@ export class GameWorld extends Container {
   protected fogTiles: Map<string, Graphics> = new Map();
   protected unitContainer: Container = new Container();
   protected fogContainer: Container = new Container();
+  // Holds every tile/unit/fog/highlight sprite, offset by (-minX, -minY) so
+  // the board's true top-left corner sits at local (0, 0) — see the
+  // constructor's own comment for why pixi-viewport needs that to be true.
+  protected worldContainer: Container = new Container();
 
   constructor(
     protected board: Board,
@@ -91,17 +95,33 @@ export class GameWorld extends Container {
     super();
     this.game = new Game(board);
 
+    const state = this.game.world.getState();
+    // Flat-top hexes at col/row 0 extend into negative X/Y (state.minX/minY
+    // — see core/grid/get_grid_bounding_box.ts), but pixi-viewport's clamp
+    // plugin (shared/viewport.ts's worldClamp) and its automatic "underflow"
+    // re-centering (whenever the board is smaller than the screen — the
+    // common case) both hard-assume the rendered world spans [0, worldWidth]
+    // x [0, worldHeight], with no way to tell them otherwise. worldContainer
+    // shifts every tile/unit/fog/highlight sprite by (-minX, -minY) so that
+    // assumption is actually true, and everything downstream — clamp,
+    // moveCenter, cull() — can use the simple zero-based math it expects.
+    const shiftedWidth = state.worldWidth - state.minX;
+    const shiftedHeight = state.worldHeight - state.minY;
+
     this.viewport = new GameViewport({
-      worldWidth: this.game.world.getState().worldWidth,
-      worldHeight: this.game.world.getState().worldHeight,
+      worldWidth: shiftedWidth,
+      worldHeight: shiftedHeight,
       events,
     });
+
+    this.worldContainer.position.set(-state.minX, -state.minY);
+    this.viewport.addChild(this.worldContainer);
 
     this.boundary = new EventBoundary(this.viewport);
 
     this.renderTerrain();
-    this.viewport.addChild(this.unitContainer);
-    this.viewport.addChild(this.fogContainer);
+    this.worldContainer.addChild(this.unitContainer);
+    this.worldContainer.addChild(this.fogContainer);
     this.renderFog();
     this.observeWorldUpdates();
 
@@ -275,7 +295,7 @@ export class GameWorld extends Container {
       const sprite = this.createWorldTile(hex);
       const coords = hex.coordinates();
       this.terrainTiles.set(coords, sprite);
-      this.viewport.addChild(sprite);
+      this.worldContainer.addChild(sprite);
     });
   }
 
@@ -308,16 +328,22 @@ export class GameWorld extends Container {
   cull() {
     const viewport = this.viewport;
     const corner = viewport.corner;
-    const length = viewport.children.length;
+    // Sprites live in worldContainer's frame (shifted by (-minX, -minY) from
+    // viewport's own frame — see the constructor's comment), so the
+    // viewport-frame corner is translated into that same frame before
+    // comparing it against each child's own (worldContainer-local) position.
+    const offsetX = this.worldContainer.x;
+    const offsetY = this.worldContainer.y;
+    const length = this.worldContainer.children.length;
     const margin = 150;
 
-    const left = corner.x - margin;
-    const top = corner.y - margin;
-    const right = corner.x + viewport.screenWidth + margin;
-    const bottom = corner.y + viewport.screenHeight + margin;
+    const left = corner.x - offsetX - margin;
+    const top = corner.y - offsetY - margin;
+    const right = corner.x - offsetX + viewport.screenWidth + margin;
+    const bottom = corner.y - offsetY + viewport.screenHeight + margin;
 
     for (let i = 0; i < length; i++) {
-      const child = this.viewport.children[i];
+      const child = this.worldContainer.children[i];
 
       if (!(child instanceof Sprite)) continue;
 


### PR DESCRIPTION
## Summary

PR #217 fixed `getGridBoundingBox()`'s 2x-inflation bug and added an explicit `moveCenter()` call to center MainWorld's camera on the board — but the visual symptom ("game is rendered too high and is cut off") didn't actually go away. Two compounding bugs:

1. **`getGridBoundingBox()` still measured from the wrong origin.** Flat-top hexes at col/row 0 extend into negative X/Y (their own corners reach half a tile-width/height past their center), so the board's true top-left corner was never `[0, 0]`. `moveCenter(worldWidth/2, worldHeight/2)` aimed past the board's real center by half that negative margin.

2. **pixi-viewport's `clamp` plugin was silently overriding `moveCenter()` every frame.** Whenever the board is smaller than the screen (the common case), clamp's automatic "underflow" re-centering hard-assumes the world spans `[0, worldWidth] x [0, worldHeight]` — with no way to configure otherwise. It was recentering the camera on that (wrong) assumption on every tick, which is why #217's `moveCenter()` fix never had any visible effect despite computing the right target.

## Fix

- `getGridBoundingBox()` now also reports `minX`/`minY` (the grid's true top-left corner), scanning every hex's corners rather than assuming the first/last hex is the extreme one (column offsetting in flat-top layouts can push a different hex's corner further out).
- `shared/game_world.ts` introduces a `worldContainer` that all tile/unit/fog/highlight sprites render into, shifted by `(-minX, -minY)`. This makes the board *actually* span `[0, worldWidth] x [0, worldHeight]` in viewport space, matching what pixi-viewport's clamp and `moveCenter` already assume — so both now correctly center a board smaller than the screen with no further special-casing, and `moveCenter()` goes back to the simple `worldWidth/2, worldHeight/2` form.
- Click handling (`MainWorld.handleViewportClicked`, `IntroWorld.setup()`) and `cull()` are updated to convert coordinates into `worldContainer`'s frame, since sprites moved one level deeper.

Verified via Playwright against the real intro → Stage 1 flow, at both a borderline-short viewport (1280x720, where the board's shifted height edges into pixi-viewport's non-centering "overflow" clamp branch) and a realistic desktop size (1440x900, clean centering) — the board's top row is no longer clipped in either case.

## Test plan

- [x] `astro check` — 0 errors
- [x] `vitest run` — 398/398 passing, including new regression coverage for `getGridBoundingBox`'s `minX`/`minY`
- [x] Full Playwright interaction suite (real pixel clicks through select/move/auto-attack/auto-path/intro-skip) — all passing
- [x] Manual visual verification via Playwright screenshots at two viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)