### PR TITLE
Attack a reachable enemy in one click, even when not yet adjacent

### DIFF
--- a/apps/home/interaction/click-to-attack.spec.ts
+++ b/apps/home/interaction/click-to-attack.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "@playwright/test";
+
+// spec 03 "Click on an Enemy Unit" + issue #219: a bare click-to-attack (no
+// preceding move) on an enemy already adjacent to the selected unit must
+// resolve immediately.
+test("selecting a unit then clicking an already-adjacent enemy attacks it directly", async ({
+  page,
+}) => {
+  await page.goto("/interaction-harness?enemy=adjacent");
+
+  await expect
+    .poll(() => page.evaluate(() => window.__test?.getUnitSectionByOwner("human")))
+    .toBe("harness_start");
+  await expect
+    .poll(() => page.evaluate(() => window.__test?.isSectionOccupied("harness_adjacent_enemy_spot")))
+    .toBe(true);
+
+  const start = await page.evaluate(() =>
+    window.__test!.getTileScreenPositionBySection("harness_start")
+  );
+  const enemySpot = await page.evaluate(() =>
+    window.__test!.getTileScreenPositionBySection("harness_adjacent_enemy_spot")
+  );
+  if (!start || !enemySpot) throw new Error("harness tiles not found on screen");
+
+  await page.mouse.click(start.x, start.y); // select the Hero
+  await page.mouse.click(enemySpot.x, enemySpot.y); // attack the adjacent enemy directly
+
+  await expect
+    .poll(() => page.evaluate(() => window.__test?.isSectionOccupied("harness_adjacent_enemy_spot")))
+    .toBe(false);
+  // The Hero never had to move to land this attack.
+  expect(
+    await page.evaluate(() => window.__test?.getUnitSectionByOwner("human"))
+  ).toBe("harness_start");
+});
+
+// spec 03 "Click on an Enemy Unit" + issue #219: clicking an enemy that
+// isn't adjacent yet, but that the selected unit can still reach (a hex next
+// to it lies within move range) and attack this turn, auto-paths the unit
+// there and resolves the attack in the same click — the player already
+// declared which enemy they want by clicking it.
+test("clicking a reachable-but-not-adjacent enemy auto-paths next to it and attacks it", async ({
+  page,
+}) => {
+  await page.goto("/interaction-harness?enemy=1");
+
+  await expect
+    .poll(() => page.evaluate(() => window.__test?.getUnitSectionByOwner("human")))
+    .toBe("harness_start");
+  await expect
+    .poll(() => page.evaluate(() => window.__test?.isSectionOccupied("harness_enemy_spot")))
+    .toBe(true);
+
+  const start = await page.evaluate(() =>
+    window.__test!.getTileScreenPositionBySection("harness_start")
+  );
+  const enemySpot = await page.evaluate(() =>
+    window.__test!.getTileScreenPositionBySection("harness_enemy_spot")
+  );
+  if (!start || !enemySpot) throw new Error("harness tiles not found on screen");
+
+  await page.mouse.click(start.x, start.y); // select the Hero
+  await page.mouse.click(enemySpot.x, enemySpot.y); // click the enemy directly (2 hexes away)
+
+  await expect
+    .poll(() => page.evaluate(() => window.__test?.isSectionOccupied("harness_enemy_spot")))
+    .toBe(false);
+  // The Hero walked to the nearest hex adjacent to the enemy to land the hit.
+  await expect
+    .poll(() => page.evaluate(() => window.__test?.getUnitSectionByOwner("human")))
+    .toBe("harness_next");
+});

--- a/apps/home/specs/03-player-input.md
+++ b/apps/home/specs/03-player-input.md
@@ -26,8 +26,9 @@ The player input system translates a human player's hex-click gestures into game
 ### Click on an Enemy Unit
 
 - The player clicks a hex occupied by an enemy unit.
-- If the enemy is adjacent to the player's unit and the player's unit has not yet used its attack action this turn, an attack is initiated.
-- If the enemy is not adjacent, no action is taken.
+- If the enemy is adjacent to the player's unit and the player's unit has not yet used its attack action this turn, an attack is initiated immediately.
+- If the enemy is not adjacent, but a hex adjacent to it lies within the player's unit's move range (reachable this turn, not just the adjacent ring) and the unit has not yet used its attack action, the unit auto-paths to the nearest such hex (fewest steps; ties resolved by move-range's own discovery order) and then attacks the clicked enemy — mirroring Click on an Empty Hex's auto-path, but ending in an attack against the exact enemy clicked rather than wherever eligible targets happen to be after the move.
+- If no such hex exists — the enemy is out of reach this turn, or every hex adjacent to it is occupied — no action is taken.
 
 ### Auto-Attack on Move
 
@@ -61,6 +62,8 @@ The player input system translates a human player's hex-click gestures into game
 - Clicking a hex within the unit's move range but not adjacent auto-paths the unit there in one click.
 - Clicking a hex outside the unit's move range does not move the unit.
 - Clicking an adjacent enemy initiates combat (if attack not yet used).
+- Clicking a non-adjacent enemy that the unit can still reach and attack this turn auto-paths next to it and attacks it in the same click.
+- Clicking a non-adjacent enemy the unit cannot reach this turn has no effect.
 - A move that lands next to exactly one eligible enemy attacks it automatically.
 - A move that lands next to two or more eligible enemies does not auto-attack; a follow-up click on one of them does.
 - Clicking during enemy turn has no effect.

--- a/apps/home/src/game/main/game_world.ts
+++ b/apps/home/src/game/main/game_world.ts
@@ -6,7 +6,7 @@ import type { EventSystem, Spritesheet } from "pixi.js";
 import { Text, Container, Graphics, Rectangle, EventEmitter } from "pixi.js";
 import TWEEN, { type Tween } from "@tweenjs/tween.js";
 import { pointToCube } from "../core/grid/helpers";
-import { cubeKey } from "../core/grid";
+import { cubeKey, hexDistance } from "../core/grid";
 import { moveRange, pathTo, validAttackTargets } from "../core/player/movement";
 import type { Tileable } from "../shared/renderable/tileable";
 import type { UnitPosition } from "../core/board";
@@ -19,6 +19,7 @@ import { DialogBox } from "../shared/dialog_box";
 import { CompletionScreen } from "../shared/completion_screen";
 import type { StageDefinition } from "./stages/stage";
 import type { Unit } from "../core/units/unit";
+import { isDamaging } from "../core/units";
 import type { Direction } from "../core/direction";
 
 // How long the attack-target frame is visible before an auto-attack's damage
@@ -441,7 +442,15 @@ export class MainWorld extends GameWorld {
         return;
       }
 
-      this.handleManualAttack(unitOnTile, state);
+      const attacked = this.handleManualAttack(unitOnTile, state);
+      if (!attacked) {
+        // Not adjacent yet: if the selected unit can still reach a hex next
+        // to this enemy and attack this turn, walk it there and attack in
+        // the same click (spec 03 "Click on an Enemy Unit") — mirrors "Click
+        // on an Empty Hex"'s auto-path, but for an enemy target instead of a
+        // destination tile. If no such hex is reachable, this is a no-op.
+        await this.handleApproachAndAttack(unitOnTile, state);
+      }
       return;
     }
 
@@ -459,10 +468,12 @@ export class MainWorld extends GameWorld {
   // Enemy/NPC unit clicked: attack only if it is a legal target for the
   // selected unit's remaining attack charge — validAttackTargets applies
   // the same adjacency + Damageable + charge checks the reducer enforces
-  // (spec 03 "Click on an Enemy Unit").
-  protected handleManualAttack(target: UnitPosition, state: State) {
+  // (spec 03 "Click on an Enemy Unit"). Returns whether the attack resolved,
+  // so the caller can fall back to handleApproachAndAttack when it didn't
+  // (e.g. the target isn't adjacent yet).
+  protected handleManualAttack(target: UnitPosition, state: State): boolean {
     if (!this.selectedUnit) {
-      return;
+      return false;
     }
 
     const targets = validAttackTargets(this.selectedUnit.unit, this.selectedUnit.position, "human", state);
@@ -473,7 +484,65 @@ export class MainWorld extends GameWorld {
       // must reflect the post-attack state, not linger from selection
       // time (spec 03 "Visual Feedback").
       this.updateHighlights();
+      return true;
     }
+    return false;
+  }
+
+  // Enemy clicked while not yet adjacent: if a hex next to it lies within
+  // the selected unit's move range and the unit hasn't used its attack this
+  // turn, auto-path to the nearest such hex (fewest steps; ties keep
+  // moveRange's BFS discovery order) and attack the clicked enemy directly —
+  // the player already declared which one they want, so this skips the
+  // ambiguous-target highlight flow resolveAutoAttack uses for a plain move
+  // onto a hex adjacent to several eligible enemies. A no-op when no
+  // reachable adjacent hex exists (out of range, or all occupied).
+  protected async handleApproachAndAttack(target: UnitPosition, state: State) {
+    if (!this.selectedUnit) {
+      return;
+    }
+    const unit = this.selectedUnit.unit;
+    if (!isDamaging(unit) || !unit.canAttack()) {
+      return;
+    }
+
+    const approachHexes = moveRange(unit, this.selectedUnit.position, state).filter(
+      (hex) => hexDistance(hex, target.position) === 1
+    );
+    if (approachHexes.length === 0) {
+      return;
+    }
+
+    let bestPath: Direction[] | null = null;
+    for (const hex of approachHexes) {
+      const path = pathTo(unit, this.selectedUnit.position, hex, state);
+      if (path && (!bestPath || path.length < bestPath.length)) {
+        bestPath = path;
+      }
+    }
+    if (!bestPath) {
+      return;
+    }
+
+    const movedUnitId = unit.id;
+    const moveOutcome = await this.executeMovePath(unit, bestPath);
+    if (moveOutcome !== "completed") {
+      return;
+    }
+
+    const postMoveState = this.game.world.getState();
+    const moved = this.findUnitById(postMoveState, movedUnitId);
+    if (!moved) {
+      return;
+    }
+    // Re-validate: the target may have died or moved (e.g. a narrative
+    // trigger fired mid-path) while we were walking over.
+    const targets = validAttackTargets(moved.unit, moved.position, "human", postMoveState);
+    if (targets.some((t) => cubeKey(t) === cubeKey(target.position))) {
+      this.selectedUnit = moved;
+      this.scenario.attackUnit(moved.unit, target.position);
+    }
+    this.reselectAfterMove(movedUnitId);
   }
 
   // Move the selected unit — possibly several steps in one click, to any

--- a/apps/home/src/game/main/harness/interaction_harness.ts
+++ b/apps/home/src/game/main/harness/interaction_harness.ts
@@ -7,13 +7,14 @@ import { Hero } from "../units";
 import type { StageDefinition, UnitSpawn } from "../stages/stage";
 import type { NarrativeScript } from "../../core/narrative";
 
-// Deliberately minimal (docs/adr/0001): three tiles in a row plus two hexes
-// adjacent to "harness_next" ("harness_enemy_spot" and "harness_enemy_spot_2"),
-// one Hero, no enemies by default. Enough to drive the real click -> select ->
-// click -> move path through MainWorld without mounting Stage 1's wolves or
-// narrative. The second row exists only so an opt-in enemy (or two) has a hex
-// adjacent to "harness_next"/"harness_far" to stand on — a 1-row board can't
-// express that adjacency at all.
+// Deliberately minimal (docs/adr/0001): three tiles in a row plus three hexes
+// on the row below — "harness_adjacent_enemy_spot" (adjacent to
+// "harness_start" itself) and "harness_enemy_spot"/"harness_enemy_spot_2"
+// (adjacent to "harness_next") — one Hero, no enemies by default. Enough to
+// drive the real click -> select -> click -> move path through MainWorld
+// without mounting Stage 1's wolves or narrative. The second row exists only
+// so an opt-in enemy (or two) has a hex adjacent to a first-row tile to stand
+// on — a 1-row board can't express that adjacency at all.
 export function createHarnessBoard(): Board {
   return {
     rows: 2,
@@ -22,7 +23,7 @@ export function createHarnessBoard(): Board {
       { x: 0, y: 0, type: Terrain.WATER, textureName: "grass", sectionName: "harness_start" },
       { x: 1, y: 0, type: Terrain.WATER, textureName: "grass", sectionName: "harness_next" },
       { x: 2, y: 0, type: Terrain.WATER, textureName: "grass", sectionName: "harness_far" },
-      { x: 0, y: 1, type: Terrain.WATER, textureName: "grass", sectionName: "none" },
+      { x: 0, y: 1, type: Terrain.WATER, textureName: "grass", sectionName: "harness_adjacent_enemy_spot" },
       { x: 1, y: 1, type: Terrain.WATER, textureName: "grass", sectionName: "harness_enemy_spot_2" },
       { x: 2, y: 1, type: Terrain.WATER, textureName: "grass", sectionName: "harness_enemy_spot" },
     ],
@@ -83,6 +84,17 @@ export function createHarnessDefinitionWithTwoEnemies(): StageDefinition {
   return withHarnessEnemies([
     { section: "harness_enemy_spot", createUnit: () => new HarnessTarget() },
     { section: "harness_enemy_spot_2", createUnit: () => new HarnessTarget() },
+  ]);
+}
+
+// Opt-in (interaction-harness.astro's default stays enemy-free per docs/adr/0001).
+// Exists for interaction/click-to-attack.spec.ts (issue #219): a bare
+// click-to-attack with no preceding move — "harness_adjacent_enemy_spot" sits
+// next to "harness_start" itself, unlike the other enemy spots above, which
+// only became adjacent after the Hero moved onto "harness_next".
+export function createHarnessDefinitionWithAdjacentEnemy(): StageDefinition {
+  return withHarnessEnemies([
+    { section: "harness_adjacent_enemy_spot", createUnit: () => new HarnessTarget() },
   ]);
 }
 

--- a/apps/home/src/pages/interaction-harness.astro
+++ b/apps/home/src/pages/interaction-harness.astro
@@ -42,6 +42,7 @@ if (!import.meta.env.DEV) {
         createHarnessDefinition,
         createHarnessDefinitionWithEnemy,
         createHarnessDefinitionWithTwoEnemies,
+        createHarnessDefinitionWithAdjacentEnemy,
         createHarnessNarrativeScript,
       } from "../game/main/harness/interaction_harness";
       import { cubeKey } from "../game/core/grid/helpers";
@@ -73,9 +74,11 @@ if (!import.meta.env.DEV) {
         // ambiguous-targets case.
         const definition = params.get("enemy") === "2"
           ? createHarnessDefinitionWithTwoEnemies()
-          : params.has("enemy")
-            ? createHarnessDefinitionWithEnemy()
-            : createHarnessDefinition();
+          : params.get("enemy") === "adjacent"
+            ? createHarnessDefinitionWithAdjacentEnemy()
+            : params.has("enemy")
+              ? createHarnessDefinitionWithEnemy()
+              : createHarnessDefinition();
 
         const world = new MainWorld(
           createHarnessBoard(),


### PR DESCRIPTION
## Summary

Reproduces issue #219 ("clicking the enemy unit to attack it, my unit doesn't move and does not attack it") with a Playwright harness scenario: clicking an enemy that isn't immediately adjacent used to silently do nothing — spec 03 required strict adjacency and gave up otherwise.

- Click-to-attack now auto-paths the selected unit to the nearest reachable hex adjacent to the clicked enemy (mirroring click-to-move's auto-path, ADR-0003) and attacks that specific enemy in the same click, whenever the unit has movement budget to get there and an unused attack action.
- If no such hex is reachable (out of range, or every adjacent hex is occupied), it's still a no-op, as before.
- `handleManualAttack` now returns whether it resolved, so `handleTileClick` can fall back to the new `handleApproachAndAttack` only when the enemy wasn't already adjacent.
- Updated `specs/03-player-input.md`'s "Click on an Enemy Unit" section and acceptance criteria.
- Added a harness enemy spot adjacent to the Hero's start tile (`harness_adjacent_enemy_spot`, opt-in via `?enemy=adjacent`) since no existing interaction test covered a bare click-to-attack with no preceding move.

## Test plan
- [x] `npx vitest run` — 398 tests pass
- [x] `npx playwright test` — 11/11 interaction tests pass, including 2 new regression tests in `interaction/click-to-attack.spec.ts`:
  - clicking an already-adjacent enemy attacks it directly
  - clicking a reachable-but-not-adjacent enemy auto-paths next to it and attacks it
- [x] `npx astro check` / `npx tsc --noEmit` — clean
- [x] Manually reproduced the reported bug against the dev server before the fix, confirmed fixed after

Fixes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)