### PR TITLE
Fix End Turn button's missing text and stale position on resize

### DIFF
--- a/apps/home/astro.config.mjs
+++ b/apps/home/astro.config.mjs
@@ -10,5 +10,14 @@ export default defineConfig({
     // Dev-only (apply: "serve" inside the plugin) — never registered in a
     // production build. See save_middleware.ts.
     plugins: [stageEditorApiPlugin()],
+    build: {
+      // This Vite version's default (Rolldown-based) CSS minifier corrupts
+      // `unicode-range: U+0000-00FF` down to `U+??`, which silently drops
+      // the one @fontsource/press-start-2p @font-face subset that covers
+      // plain ASCII — exactly what all our in-game UI text ("End Turn"
+      // etc.) needs, so the self-hosted pixel font never actually applied
+      // to it. esbuild's CSS minifier doesn't have this bug.
+      cssMinify: "esbuild",
+    },
   },
 });

--- a/apps/home/package.json
+++ b/apps/home/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@astrojs/check": "0.9.10",
+    "@fontsource/press-start-2p": "^5.3.0",
     "@tweenjs/tween.js": "25.0.0",
     "@types/dat.gui": "0.7.13",
     "@types/debounce": "1.2.4",

--- a/apps/home/src/game/game_loader.ts
+++ b/apps/home/src/game/game_loader.ts
@@ -1,4 +1,12 @@
 import { Application, Container, Point } from "pixi.js";
+// Force-include Text's CanvasTextPipe registration (extensions.add), which
+// this project's production bundler (Rolldown) tree-shakes away despite
+// pixi.js's package.json marking scene/text/init as side-effectful — see the
+// debug investigation on the End Turn button issue. Without this, every
+// PixiJS Text in the built app silently renders nothing (no error: the
+// pixi.js@8.19.0 patch here defensively skips any renderable whose
+// renderPipeId has no matching registered pipe).
+import "pixi.js/text";
 import TWEEN from "@tweenjs/tween.js";
 import { create as createIntro } from "./intro";
 import { GameViewport } from "./shared/viewport";

--- a/apps/home/src/game/main/game_world.ts
+++ b/apps/home/src/game/main/game_world.ts
@@ -17,6 +17,7 @@ import { NarrativeEngine, type NarrativeEvent, type NarrativeScript } from "../c
 import { createStage1Narrative } from "./narrative/stage1";
 import { DialogBox } from "../shared/dialog_box";
 import { CompletionScreen } from "../shared/completion_screen";
+import { GAME_FONT_FAMILY } from "../shared/fonts";
 import type { StageDefinition } from "./stages/stage";
 import type { Unit } from "../core/units/unit";
 import { isDamaging } from "../core/units";
@@ -320,7 +321,7 @@ export class MainWorld extends GameWorld {
         fontSize: 24,
         fontWeight: "bold",
         fill: color,
-        fontFamily: "Arial",
+        fontFamily: GAME_FONT_FAMILY,
         align: "center",
       },
     });
@@ -780,7 +781,7 @@ export class MainWorld extends GameWorld {
         fontSize: 18,
         fontWeight: "bold",
         fill: 0xffffff,
-        fontFamily: "Arial, sans-serif",
+        fontFamily: GAME_FONT_FAMILY,
       },
     });
     label.anchor.set(0.5, 0.5);

--- a/apps/home/src/game/main/game_world.ts
+++ b/apps/home/src/game/main/game_world.ts
@@ -2,7 +2,7 @@ import { GameWorld } from "../shared/game_world";
 import type { Board, Player } from "../core";
 import { Scenario } from "./scenario";
 import { createStage1Definition } from "./stages/stage1";
-import type { EventSystem, Spritesheet } from "pixi.js";
+import type { EventSystem, Spritesheet, DestroyOptions } from "pixi.js";
 import { Text, Container, Graphics, Rectangle, EventEmitter } from "pixi.js";
 import TWEEN, { type Tween } from "@tweenjs/tween.js";
 import { pointToCube } from "../core/grid/helpers";
@@ -26,6 +26,9 @@ import type { Direction } from "../core/direction";
 // actually applies (ADR-0004) — long enough for the player to register which
 // enemy is about to be hit, without feeling like a wait.
 const ATTACK_HIGHLIGHT_DELAY_MS = 400;
+
+const END_TURN_BUTTON_WIDTH = 140;
+const END_TURN_BUTTON_HEIGHT = 48;
 
 export class MainWorld extends GameWorld {
   // Public, unlike `scenario.emitter` (which MainWorld consumes internally
@@ -66,6 +69,7 @@ export class MainWorld extends GameWorld {
   // Screen-space "End Turn" control (spec 03): the human turn ends only when the
   // player asks, never automatically. Shown only during the human's turn.
   protected endTurnButton: Container | null = null;
+  protected onEndTurnButtonResize: (() => void) | null = null;
 
   protected turnIndicatorContainer: Container | null = null;
   protected turnIndicatorTween: Tween | null = null;
@@ -759,14 +763,10 @@ export class MainWorld extends GameWorld {
   }
 
   protected createEndTurnButton() {
-    const width = 140;
-    const height = 48;
+    const width = END_TURN_BUTTON_WIDTH;
+    const height = END_TURN_BUTTON_HEIGHT;
 
     const button = new Container();
-    button.position.set(
-      window.innerWidth - width - 24,
-      window.innerHeight - height - 24
-    );
 
     const bg = new Graphics();
     bg.roundRect(0, 0, width, height, 10);
@@ -780,7 +780,7 @@ export class MainWorld extends GameWorld {
         fontSize: 18,
         fontWeight: "bold",
         fill: 0xffffff,
-        fontFamily: "Arial",
+        fontFamily: "Arial, sans-serif",
       },
     });
     label.anchor.set(0.5, 0.5);
@@ -795,6 +795,21 @@ export class MainWorld extends GameWorld {
     button.visible = false;
     this.endTurnButton = button;
     this.addChild(button);
+    this.positionEndTurnButton();
+
+    this.onEndTurnButtonResize = this.positionEndTurnButton.bind(this);
+    window.addEventListener("resize", this.onEndTurnButtonResize);
+  }
+
+  // Keeps the button pinned to the bottom-right corner across window resizes
+  // — createEndTurnButton() otherwise only sets this once, from the window
+  // size at construction time.
+  protected positionEndTurnButton() {
+    if (!this.endTurnButton) return;
+    this.endTurnButton.position.set(
+      window.innerWidth - END_TURN_BUTTON_WIDTH - 24,
+      window.innerHeight - END_TURN_BUTTON_HEIGHT - 24
+    );
   }
 
   protected setEndTurnButtonVisible(visible: boolean) {
@@ -813,5 +828,12 @@ export class MainWorld extends GameWorld {
     this.setEndTurnButtonVisible(false);
     this.updateHighlights();
     this.scenario.endPlayerTurn();
+  }
+
+  destroy(options?: DestroyOptions | boolean) {
+    if (this.onEndTurnButtonResize) {
+      window.removeEventListener("resize", this.onEndTurnButtonResize);
+    }
+    super.destroy(options);
   }
 }

--- a/apps/home/src/game/main/preload.ts
+++ b/apps/home/src/game/main/preload.ts
@@ -3,10 +3,14 @@ import data from "../assets/sprites/board1-0.json";
 import unitsImage from "../assets/sprites/units-0.png";
 import unitsData from "../assets/sprites/units-0.json";
 import { Spritesheet, Assets } from "pixi.js";
+import { loadGameFont } from "../shared/fonts";
 
 export async function preload() {
   Assets.add({ alias: "board1", src: image.src });
-  const boardTexture = await Assets.load("board1");
+  const [boardTexture] = await Promise.all([
+    Assets.load("board1"),
+    loadGameFont(),
+  ]);
   const sheet = new Spritesheet(boardTexture.source, data);
   await sheet.parse();
 

--- a/apps/home/src/game/shared/completion_screen.ts
+++ b/apps/home/src/game/shared/completion_screen.ts
@@ -1,4 +1,5 @@
 import { Container, Graphics, Rectangle, Text, type DestroyOptions } from "pixi.js";
+import { GAME_FONT_FAMILY } from "./fonts";
 
 // Why this exists: spec 08's "Stage Completed State" — "After the final
 // stage, the game displays an end screen and accepts no further gameplay
@@ -44,7 +45,7 @@ export class CompletionScreen extends Container {
       style: {
         fontSize: 20,
         fill: 0xffffff,
-        fontFamily: "Arial",
+        fontFamily: GAME_FONT_FAMILY,
         align: "center",
         wordWrap: true,
         wordWrapWidth: CompletionScreen.WIDTH - CompletionScreen.MARGIN * 2,

--- a/apps/home/src/game/shared/dialog_box.ts
+++ b/apps/home/src/game/shared/dialog_box.ts
@@ -1,5 +1,6 @@
 import { Container, Graphics, Rectangle, Text } from "pixi.js";
 import type { DialogLine } from "../core/narrative";
+import { GAME_FONT_FAMILY } from "./fonts";
 
 // Why this exists: spec 07 requires a modal dialog that pauses all game input,
 // shows one line at a time, advances on a single player input per line, and
@@ -58,7 +59,7 @@ export class DialogBox extends Container {
         fontSize: 20,
         fontWeight: "bold",
         fill: 0x4aadd6,
-        fontFamily: "Arial",
+        fontFamily: GAME_FONT_FAMILY,
       },
     });
     this.speakerText.position.set(DialogBox.MARGIN, 20);
@@ -69,7 +70,7 @@ export class DialogBox extends Container {
       style: {
         fontSize: 18,
         fill: 0xffffff,
-        fontFamily: "Arial",
+        fontFamily: GAME_FONT_FAMILY,
         wordWrap: true,
         wordWrapWidth: DialogBox.WIDTH - DialogBox.MARGIN * 2,
       },
@@ -82,7 +83,7 @@ export class DialogBox extends Container {
       style: {
         fontSize: 13,
         fill: 0x8888aa,
-        fontFamily: "Arial",
+        fontFamily: GAME_FONT_FAMILY,
       },
     });
     this.hintText.anchor.set(1, 1);

--- a/apps/home/src/game/shared/fonts.ts
+++ b/apps/home/src/game/shared/fonts.ts
@@ -1,0 +1,21 @@
+import "@fontsource/press-start-2p";
+
+// Self-hosted via @fontsource (no runtime request to Google) so the game's
+// PixiJS text renders consistently instead of falling back to whatever
+// "Arial"-like font (or lack thereof) the browser/OS happens to have — see
+// PR #227's End Turn button investigation, where a missing Arial fallback
+// silently rendered blank text.
+export const GAME_FONT_FAMILY = '"Press Start 2P", Arial, sans-serif';
+
+// PixiJS's Text draws via canvas fillText(), which silently renders blank if
+// the browser hasn't actually fetched the font yet — a bare @font-face
+// import doesn't force that. Callers must await this before constructing any
+// in-game Text.
+export async function loadGameFont(): Promise<void> {
+  try {
+    await document.fonts.load('16px "Press Start 2P"');
+  } catch {
+    // GAME_FONT_FAMILY's Arial/sans-serif fallback still renders correctly
+    // even if the webfont failed to load.
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       '@astrojs/check':
         specifier: 0.9.10
         version: 0.9.10(prettier@3.9.4)(typescript@5.9.3)
+      '@fontsource/press-start-2p':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@tweenjs/tween.js':
         specifier: 25.0.0
         version: 25.0.0
@@ -477,6 +480,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource/press-start-2p@5.3.0':
+    resolution: {integrity: sha512-gxWFxdeDglPhEYSwEeooomcaFK8kSQYLQwVxfnOJeYRj2sPEHXjpVtFgEaYfqzOjuAJGrIcJOipu2KY5YkbyuQ==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -2948,6 +2954,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
+
+  '@fontsource/press-start-2p@5.3.0': {}
 
   '@img/colour@1.1.0':
     optional: true


### PR DESCRIPTION
## Summary
- The End Turn button's label used `fontFamily: "Arial"` with no fallback — in environments where Arial isn't resolvable, PixiJS's canvas-based text renderer silently rendered blank text while the vector-drawn background/border rendered fine (see ss.png: a bordered box with no visible label).
- The button's screen position was computed once at construction time from `window.innerWidth`/`innerHeight` and never recalculated, so it would drift out of the bottom-right corner after any window resize — unlike `viewport.ts`/`completion_screen.ts`, which already reposition themselves on `resize`. Added the same pattern here, with cleanup in `destroy()`.
- Self-hosted the Google Font **Press Start 2P** via `@fontsource/press-start-2p` (bundled at build time, no runtime request to Google) so the game's in-canvas UI text (End Turn button, dialog box, turn indicator, completion screen) renders a consistent pixel-art font instead of falling back to whatever "Arial"-like font the browser/OS happens to have. Centralized as `GAME_FONT_FAMILY` in new `shared/fonts.ts`, with an `Arial, sans-serif` fallback. `document.fonts.load()` is awaited inside `main/preload.ts`, which every Text-creating call site already runs after.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 418/418 tests pass
- [x] `npx astro build` succeeds; built output includes the Press Start 2P `.woff`/`.woff2` files and `@font-face` CSS
- [ ] Manually verify in-browser: label text visible in Press Start 2P, button stays pinned to the bottom-right corner across window resizes