### PR TITLE
Fix empty preview URL: enable and sync Worker preview URLs

### DIFF
--- a/.github/workflows/preview_home.yml
+++ b/.github/workflows/preview_home.yml
@@ -83,6 +83,21 @@ jobs:
           name: home-dist
           path: apps/home/dist
 
+      # `versions upload` only reads whether preview URLs are enabled for
+      # this Worker (a GET against .../subdomain) — it never turns that
+      # setting on. workers_dev/preview_urls in wrangler.jsonc only take
+      # effect once synced server-side, which `triggers deploy` does without
+      # touching which version serves production traffic (unlike `versions
+      # deploy`). Without this, `versions upload` silently omits preview_url
+      # and the PR comment below ends up with an empty URL.
+      - name: Sync Worker triggers (enables preview URLs)
+        uses: cloudflare/wrangler-action@v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/home
+          command: triggers deploy
+
       - name: Deploy to Cloudflare Workers
         id: deploy
         uses: cloudflare/wrangler-action@v4.0.0

--- a/apps/home/wrangler.jsonc
+++ b/apps/home/wrangler.jsonc
@@ -5,6 +5,8 @@
   // asset fast path with no Worker invocation at all.
   "name": "ertrzyiks-me",
   "compatibility_date": "2026-08-03",
+  "workers_dev": true,
+  "preview_urls": true,
   "assets": {
     "directory": "./dist"
   }


### PR DESCRIPTION
The PR comment showed "Preview deployed: " with the URL missing. `versions upload` only reads whether preview URLs are enabled for the Worker (a GET against .../subdomain) — it never turns that setting on itself, and it was never enabled for this Worker, so preview_url came back undefined every time with no error.

- wrangler.jsonc: add workers_dev/preview_urls (both true) so future syncs know the desired state.
- Workflow: run `wrangler triggers deploy` before `versions upload`. triggers deploy is the command that actually applies workers_dev/preview_urls (and routes/cron) server-side, without touching which version serves production traffic (that's `versions deploy`, a separate, unrelated command) — safe to run on every PR build alongside the existing ephemeral versions upload.