### PR TITLE
Add one-time Gmail OAuth bootstrap script

### DIFF
--- a/scripts/gmail-oauth/README.md
+++ b/scripts/gmail-oauth/README.md
@@ -1,0 +1,80 @@
+# Gmail OAuth bootstrap
+
+One-time script for [#247](https://github.com/ertrzyiks/ertrzyiks.me/issues/247). Produces the
+single `gmail.readonly` refresh token shared by `personal-assistant` (orchestration, cloud) and
+the `task-manager` Mac worker, per the design in #236.
+
+Run this locally on your Mac, not in CI or any sandbox — it needs a real browser for the consent
+screen and its output is a live credential.
+
+## 1. Create the Google Cloud OAuth client (manual, your side)
+
+1. Create/select a Google Cloud project.
+2. Enable the **Gmail API** for it.
+3. OAuth consent screen: add yourself as a **test user** (the app stays in "Testing" publishing
+   status — `gmail.readonly` is a sensitive scope and full verification isn't worth it for a
+   single-user personal tool).
+4. Create an OAuth client of type **Desktop app**. Desktop clients accept any
+   `http://localhost:<port>/...` redirect URI without pre-registration, which is why this script
+   doesn't need you to register a redirect URI up front.
+5. Note the generated **Client ID** and **Client secret**.
+
+## 2. Run the script
+
+```bash
+cd scripts/gmail-oauth
+npm install
+GMAIL_OAUTH_CLIENT_ID=<client id> GMAIL_OAUTH_CLIENT_SECRET=<client secret> npm run get-refresh-token
+```
+
+It prints a Google consent URL, spins up a temporary localhost server to catch the redirect, and
+once you complete consent in the browser it exchanges the code for tokens and prints:
+
+```
+GMAIL_OAUTH_CLIENT_ID:     ...
+GMAIL_REFRESH_TOKEN:       ...
+```
+
+(the client secret isn't echoed back — you already have it, it's the value you passed in). The
+refresh token is only ever shown here — Google doesn't let you retrieve it again later. If a
+run ever prints "No refresh_token was returned", it means this Google account already consented
+for this client before; revoke access at https://myaccount.google.com/permissions and re-run.
+
+## 3. Store the values
+
+**1Password** (vault `Dokku apps`, item names as expected by the Terraform in #252):
+
+| 1Password item                             | Value                       |
+| -------------------------------------------- | ---------------------------- |
+| `gmail_oauth_client_id`                      | `GMAIL_OAUTH_CLIENT_ID`      |
+| `gmail_oauth_client_secret`                  | `GMAIL_OAUTH_CLIENT_SECRET`  |
+| `personal_assistant_gmail_refresh_token`     | `GMAIL_REFRESH_TOKEN`        |
+
+Either create these by hand in the 1Password app/GUI, or with the `op` CLI if you have it set up, e.g.:
+
+```bash
+op item create --category=password --vault="Dokku apps" \
+  --title="personal_assistant_gmail_refresh_token" \
+  "password=<GMAIL_REFRESH_TOKEN value>"
+```
+(repeat for the other two items)
+
+**macOS Keychain** (read by the Mac worker at startup — implemented in #251, this just captures
+the secret now while you have it):
+
+```bash
+security add-generic-password \
+  -a "$USER" \
+  -s "task-manager-gmail-refresh-token" \
+  -w "<GMAIL_REFRESH_TOKEN value>"
+```
+
+The service name above (`task-manager-gmail-refresh-token`) is provisional — #251 owns the actual
+Keychain read implementation and can rename it there if it picks a different convention.
+
+## Notes
+
+- This is the same refresh token in both places — one shared `gmail.readonly` credential per the
+  decision in #236, not two separate ones.
+- This script and its `node_modules` are not part of the `apps/*` pnpm workspace and are not
+  deployed anywhere; it's a throwaway bootstrap tool.

--- a/scripts/gmail-oauth/get-refresh-token.mjs
+++ b/scripts/gmail-oauth/get-refresh-token.mjs
@@ -1,0 +1,83 @@
+import http from "node:http";
+import { OAuth2Client } from "google-auth-library";
+
+const SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
+
+const clientId = process.env.GMAIL_OAUTH_CLIENT_ID;
+const clientSecret = process.env.GMAIL_OAUTH_CLIENT_SECRET;
+
+if (!clientId || !clientSecret) {
+  console.error(
+    "Missing credentials. Set GMAIL_OAUTH_CLIENT_ID and GMAIL_OAUTH_CLIENT_SECRET " +
+      "(from the Desktop app OAuth client you created in Google Cloud Console) and re-run.",
+  );
+  process.exit(1);
+}
+
+// Port 0 lets the OS assign a free loopback port. Desktop-app OAuth clients
+// accept any http://localhost:<port>/... redirect URI without pre-registration,
+// which is the whole reason issue #247 specifies the "Desktop app" client type.
+const server = http.createServer();
+await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+const port = server.address().port;
+const redirectUri = `http://127.0.0.1:${port}/oauth2callback`;
+
+const client = new OAuth2Client(clientId, clientSecret, redirectUri);
+
+const authUrl = client.generateAuthUrl({
+  access_type: "offline",
+  scope: [SCOPE],
+  // Forces the consent screen even if this Google account already granted
+  // this client access before — without it, Google may skip issuing a new
+  // refresh_token on a repeat consent.
+  prompt: "consent",
+});
+
+console.log("Open this URL in a browser and complete the consent flow:\n");
+console.log(authUrl);
+console.log("\nWaiting for the redirect back to this script...");
+
+const { code } = await new Promise((resolve, reject) => {
+  server.on("request", (req, res) => {
+    const url = new URL(req.url, redirectUri);
+    if (url.pathname !== "/oauth2callback") {
+      res.writeHead(404).end();
+      return;
+    }
+
+    const error = url.searchParams.get("error");
+    if (error) {
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end(`Consent denied or failed: ${error}. You can close this tab.`);
+      reject(new Error(`OAuth consent error: ${error}`));
+      return;
+    }
+
+    const code = url.searchParams.get("code");
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end(
+      "Consent captured. You can close this tab and return to the terminal.",
+    );
+    resolve({ code });
+  });
+});
+
+server.close();
+
+const { tokens } = await client.getToken(code);
+
+if (!tokens.refresh_token) {
+  console.error(
+    "\nNo refresh_token was returned. This Google account most likely already " +
+      "granted this OAuth client consent before. Revoke prior access at " +
+      "https://myaccount.google.com/permissions and re-run this script.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  "\nSuccess. Store these values now — the refresh token is shown only once:\n",
+);
+console.log(`GMAIL_OAUTH_CLIENT_ID:     ${clientId}`);
+console.log(`GMAIL_REFRESH_TOKEN:       ${tokens.refresh_token}`);
+console.log("\nSee README.md in this folder for where each value needs to go.");

--- a/scripts/gmail-oauth/package-lock.json
+++ b/scripts/gmail-oauth/package-lock.json
@@ -1,0 +1,282 @@
+{
+  "name": "gmail-oauth-bootstrap",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gmail-oauth-bootstrap",
+      "version": "0.0.0",
+      "dependencies": {
+        "google-auth-library": "^11.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.0.tgz",
+      "integrity": "sha512-WC5gkb2pElGhZKgGx9r799trH3ZUx90ecgIOIMmgiiHS/gzO3r4vvFoQWuKI0QmR2xU5uee2M4hDUxRZDh/x7w==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  }
+}

--- a/scripts/gmail-oauth/package.json
+++ b/scripts/gmail-oauth/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "gmail-oauth-bootstrap",
+  "version": "0.0.0",
+  "private": true,
+  "description": "One-time local script to obtain the shared gmail.readonly refresh token (see issue #247)",
+  "type": "module",
+  "scripts": {
+    "get-refresh-token": "node get-refresh-token.mjs"
+  },
+  "dependencies": {
+    "google-auth-library": "^11.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `scripts/gmail-oauth/`, a standalone one-time script (not part of the `apps/*` pnpm workspace) that completes the `gmail.readonly` consent flow and mints the refresh token shared by `personal-assistant` and the `task-manager` Mac worker, per the credential design in #236.
- README documents the full manual flow: creating the Desktop-app OAuth client in Google Cloud Console, running the script, and where each value goes afterwards (1Password item names matching #252's Terraform spec, plus the macOS Keychain command for the worker side from #251).

Closes #247 — Google Cloud project/OAuth client creation, running the script, and storing the resulting values in 1Password + Keychain were completed manually alongside this PR.

## Test plan
- [x] `npm install` in `scripts/gmail-oauth` completes cleanly
- [x] `node --check get-refresh-token.mjs` passes
- [x] Smoke-tested the script prints a well-formed consent URL with a dynamically-assigned loopback redirect
- [x] End-to-end run completed manually: consent flow succeeded, refresh token obtained and stored in 1Password + macOS Keychain