### PR TITLE
Provision task-manager and personal-assistant Dokku apps

### DIFF
--- a/scripts/gmail-oauth/README.md
+++ b/scripts/gmail-oauth/README.md
@@ -44,17 +44,17 @@ for this client before; revoke access at https://myaccount.google.com/permission
 
 **1Password** (vault `Dokku apps`, item names as expected by the Terraform in #252):
 
-| 1Password item                             | Value                       |
-| -------------------------------------------- | ---------------------------- |
-| `gmail_oauth_client_id`                      | `GMAIL_OAUTH_CLIENT_ID`      |
-| `gmail_oauth_client_secret`                  | `GMAIL_OAUTH_CLIENT_SECRET`  |
-| `personal_assistant_gmail_refresh_token`     | `GMAIL_REFRESH_TOKEN`        |
+| 1Password item                                    | Value                       |
+| ---------------------------------------------------- | ---------------------------- |
+| `personal_assistant_gcloud_oauth_client_id`          | `GMAIL_OAUTH_CLIENT_ID`      |
+| `personal_assistant_gcloud_oauth_client_secret`      | `GMAIL_OAUTH_CLIENT_SECRET`  |
+| `personal_assistant_gcloud_oauth_refresh_token`      | `GMAIL_REFRESH_TOKEN`        |
 
 Either create these by hand in the 1Password app/GUI, or with the `op` CLI if you have it set up, e.g.:
 
 ```bash
 op item create --category=password --vault="Dokku apps" \
-  --title="personal_assistant_gmail_refresh_token" \
+  --title="personal_assistant_gcloud_oauth_refresh_token" \
   "password=<GMAIL_REFRESH_TOKEN value>"
 ```
 (repeat for the other two items)

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -33,3 +33,28 @@ data "onepassword_item" "yummy_next_algolia_search_key" {
   title = "yummy_next_algolia_search_key"
 }
 
+data "onepassword_item" "task_manager_redis_url" {
+  vault = "Dokku apps"
+  title = "task_manager_redis_url"
+}
+
+data "onepassword_item" "jobs_api_bearer_token" {
+  vault = "Dokku apps"
+  title = "jobs_api_bearer_token"
+}
+
+data "onepassword_item" "personal_assistant_gcloud_oauth_client_id" {
+  vault = "Dokku apps"
+  title = "personal_assistant_gcloud_oauth_client_id"
+}
+
+data "onepassword_item" "personal_assistant_gcloud_oauth_client_secret" {
+  vault = "Dokku apps"
+  title = "personal_assistant_gcloud_oauth_client_secret"
+}
+
+data "onepassword_item" "personal_assistant_gcloud_oauth_refresh_token" {
+  vault = "Dokku apps"
+  title = "personal_assistant_gcloud_oauth_refresh_token"
+}
+

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -33,14 +33,14 @@ data "onepassword_item" "yummy_next_algolia_search_key" {
   title = "yummy_next_algolia_search_key"
 }
 
-data "onepassword_item" "task_manager_redis_url" {
+data "onepassword_item" "personal_assistant_task_manager_redis_url" {
   vault = "Dokku apps"
-  title = "task_manager_redis_url"
+  title = "personal_assistant_task_manager_redis_url"
 }
 
-data "onepassword_item" "jobs_api_bearer_token" {
+data "onepassword_item" "personal_assistant_jobs_api_bearer_token" {
   vault = "Dokku apps"
-  title = "jobs_api_bearer_token"
+  title = "personal_assistant_jobs_api_bearer_token"
 }
 
 data "onepassword_item" "personal_assistant_gcloud_oauth_client_id" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -95,8 +95,8 @@ resource "dokku_app" "task_manager" {
   app_name = "task-manager"
 
   config = {
-    REDIS_URL             = data.onepassword_item.task_manager_redis_url.password
-    JOBS_API_BEARER_TOKEN = data.onepassword_item.jobs_api_bearer_token.password
+    REDIS_URL             = data.onepassword_item.personal_assistant_task_manager_redis_url.password
+    JOBS_API_BEARER_TOKEN = data.onepassword_item.personal_assistant_jobs_api_bearer_token.password
   }
 
   domains = ["task-manager.ertrzyiks.me"]
@@ -110,7 +110,7 @@ resource "dokku_app" "personal_assistant" {
     GMAIL_CLIENT_ID       = data.onepassword_item.personal_assistant_gcloud_oauth_client_id.password
     GMAIL_CLIENT_SECRET   = data.onepassword_item.personal_assistant_gcloud_oauth_client_secret.password
     GMAIL_REFRESH_TOKEN   = data.onepassword_item.personal_assistant_gcloud_oauth_refresh_token.password
-    JOBS_API_BEARER_TOKEN = data.onepassword_item.jobs_api_bearer_token.password
+    JOBS_API_BEARER_TOKEN = data.onepassword_item.personal_assistant_jobs_api_bearer_token.password
     JOBS_API_BASE_URL     = "https://task-manager.ertrzyiks.me"
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -90,3 +90,36 @@ resource "dokku_app" "yummy_next" {
   domains = ["kuchnia-yummy.pl"]
 }
 
+# Task Manager app (Jobs API server, see #248)
+resource "dokku_app" "task_manager" {
+  app_name = "task-manager"
+
+  config = {
+    REDIS_URL             = data.onepassword_item.task_manager_redis_url.password
+    JOBS_API_BEARER_TOKEN = data.onepassword_item.jobs_api_bearer_token.password
+  }
+
+  domains = ["task-manager.ertrzyiks.me"]
+}
+
+# Personal Assistant app (email orchestration service, see #250)
+resource "dokku_app" "personal_assistant" {
+  app_name = "personal-assistant"
+
+  config = {
+    GMAIL_CLIENT_ID       = data.onepassword_item.personal_assistant_gcloud_oauth_client_id.password
+    GMAIL_CLIENT_SECRET   = data.onepassword_item.personal_assistant_gcloud_oauth_client_secret.password
+    GMAIL_REFRESH_TOKEN   = data.onepassword_item.personal_assistant_gcloud_oauth_refresh_token.password
+    JOBS_API_BEARER_TOKEN = data.onepassword_item.jobs_api_bearer_token.password
+    JOBS_API_BASE_URL     = "https://task-manager.ertrzyiks.me"
+  }
+
+  domains = ["personal-assistant.ertrzyiks.me"]
+
+  storage = {
+    personal-assistant = {
+      mount_path = "/app/data"
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- Adds `dokku_app` resources for `task-manager` and `personal-assistant` to `terraform/main.tf`, plus the matching `onepassword_item` data sources in `terraform/data.tf`, per the spec in #252.
- All 5 1Password items for this feature carry a `personal_assistant_` prefix for consistent naming: `personal_assistant_gcloud_oauth_client_id`, `personal_assistant_gcloud_oauth_client_secret`, `personal_assistant_gcloud_oauth_refresh_token`, `personal_assistant_task_manager_redis_url`, `personal_assistant_jobs_api_bearer_token`. Updated `scripts/gmail-oauth/README.md` to match the Gmail OAuth ones.

Closes #252.

## Before merging
`terraform apply` runs automatically in CI on push to `master` for `terraform/**` changes (see `.github/workflows/terraform.yml`). Before merging, make sure these 5 items exist in the `Dokku apps` 1Password vault with these exact titles, or the apply will fail:
- `personal_assistant_gcloud_oauth_client_id`
- `personal_assistant_gcloud_oauth_client_secret`
- `personal_assistant_gcloud_oauth_refresh_token`
- `personal_assistant_task_manager_redis_url` (existing Redis instance's connection string)
- `personal_assistant_jobs_api_bearer_token` (new random shared secret)

The three Gmail OAuth items were created under their old, unprefixed names as part of #247/#254 — they need renaming to the names above, not recreating with new values.

## Test plan
- [ ] Confirm the 5 1Password items exist under the new names before merge
- [ ] After merge, watch the `Terraform` GitHub Action run and confirm `terraform apply` succeeds
- [ ] Verify `task-manager.ertrzyiks.me` and `personal-assistant.ertrzyiks.me` Dokku apps exist (they'll 502 until #248/#250 actually deploy code)
