### PR TITLE
Fix task-manager: silent startup + IPv4-only bind causing localhost connection reset

### DIFF
--- a/apps/task-manager/src/app.test.ts
+++ b/apps/task-manager/src/app.test.ts
@@ -59,6 +59,20 @@ describe("task-manager app", () => {
 
       expect(response.statusCode).toBe(401);
     });
+
+    it("does not gate routes registered as siblings on the returned app instance", async () => {
+      // devServer.ts mounts Bull Board this way (app.register(...) as a
+      // sibling of createApp's internal jobs-routes plugin), specifically so
+      // it's reachable from a plain browser tab, which can't attach an
+      // Authorization header. This pins that the auth hook stays scoped to
+      // the /jobs routes and doesn't leak back out to `app` itself.
+      app.get("/sibling-route", async () => ({ ok: true }));
+      await app.ready();
+
+      const response = await app.inject({ method: "GET", url: "/sibling-route" });
+
+      expect(response.statusCode).toBe(200);
+    });
   });
 
   describe("POST /jobs", () => {

--- a/apps/task-manager/src/app.ts
+++ b/apps/task-manager/src/app.ts
@@ -33,41 +33,49 @@ export function createApp(queue: JobsQueue, bearerToken: string): FastifyInstanc
   // vitest sets NODE_ENV=test and per-request logs would just be noise.
   const app = Fastify({ logger: process.env.NODE_ENV !== "test" });
 
-  app.addHook("onRequest", async (request, reply) => {
-    if (!isValidBearerToken(request.headers.authorization, bearerToken)) {
-      await reply.code(401).send({ error: "Unauthorized" });
-    }
-  });
+  // The bearer-auth hook is scoped to this encapsulated plugin rather than
+  // added on `app` directly, so it only covers the routes below. Fastify
+  // hooks cascade to nested `register()` contexts but not to siblings — this
+  // matters because devServer.ts mounts Bull Board as a sibling on the same
+  // `app` instance, and that UI needs to be reachable from a plain browser
+  // tab, which can't attach an Authorization header.
+  app.register(async (api) => {
+    api.addHook("onRequest", async (request, reply) => {
+      if (!isValidBearerToken(request.headers.authorization, bearerToken)) {
+        await reply.code(401).send({ error: "Unauthorized" });
+      }
+    });
 
-  app.post<{ Body: { emailId?: string } }>("/jobs", async (request, reply) => {
-    const emailId = request.body?.emailId;
-    if (typeof emailId !== "string" || emailId.length === 0) {
-      return reply.code(400).send({ error: "emailId is required" });
-    }
+    api.post<{ Body: { emailId?: string } }>("/jobs", async (request, reply) => {
+      const emailId = request.body?.emailId;
+      if (typeof emailId !== "string" || emailId.length === 0) {
+        return reply.code(400).send({ error: "emailId is required" });
+      }
 
-    const job = await queue.add(QUEUE_NAME, { emailId });
-    return reply.code(201).send({ jobId: job.id });
-  });
+      const job = await queue.add(QUEUE_NAME, { emailId });
+      return reply.code(201).send({ jobId: job.id });
+    });
 
-  app.get<{ Params: { jobId: string } }>("/jobs/:jobId", async (request, reply) => {
-    const response = await buildJobStatusResponse(queue, request.params.jobId);
-    if (!response) return reply.code(404).send();
-    return reply.send(response);
-  });
+    api.get<{ Params: { jobId: string } }>("/jobs/:jobId", async (request, reply) => {
+      const response = await buildJobStatusResponse(queue, request.params.jobId);
+      if (!response) return reply.code(404).send();
+      return reply.send(response);
+    });
 
-  app.post<{ Body: { jobIds?: string[] } }>("/jobs/status", async (request, reply) => {
-    const jobIds = request.body?.jobIds;
-    if (!Array.isArray(jobIds) || jobIds.some((id) => typeof id !== "string")) {
-      return reply.code(400).send({ error: "jobIds must be an array of strings" });
-    }
+    api.post<{ Body: { jobIds?: string[] } }>("/jobs/status", async (request, reply) => {
+      const jobIds = request.body?.jobIds;
+      if (!Array.isArray(jobIds) || jobIds.some((id) => typeof id !== "string")) {
+        return reply.code(400).send({ error: "jobIds must be an array of strings" });
+      }
 
-    // Missing jobs are silently omitted — the batch endpoint has no defined
-    // per-item error shape in the #241 spec.
-    const results = (
-      await Promise.all(jobIds.map((jobId) => buildJobStatusResponse(queue, jobId)))
-    ).filter((result): result is JobStatusResponse => result !== null);
+      // Missing jobs are silently omitted — the batch endpoint has no defined
+      // per-item error shape in the #241 spec.
+      const results = (
+        await Promise.all(jobIds.map((jobId) => buildJobStatusResponse(queue, jobId)))
+      ).filter((result): result is JobStatusResponse => result !== null);
 
-    return reply.send({ results });
+      return reply.send({ results });
+    });
   });
 
   return app;

--- a/apps/task-manager/src/app.ts
+++ b/apps/task-manager/src/app.ts
@@ -28,7 +28,10 @@ async function buildJobStatusResponse(
 }
 
 export function createApp(queue: JobsQueue, bearerToken: string): FastifyInstance {
-  const app = Fastify();
+  // Fastify's logger defaults to disabled (a silent no-op `app.log`), which
+  // made server startup/errors invisible — enable it outside tests, where
+  // vitest sets NODE_ENV=test and per-request logs would just be noise.
+  const app = Fastify({ logger: process.env.NODE_ENV !== "test" });
 
   app.addHook("onRequest", async (request, reply) => {
     if (!isValidBearerToken(request.headers.authorization, bearerToken)) {

--- a/apps/task-manager/src/devServer.ts
+++ b/apps/task-manager/src/devServer.ts
@@ -19,7 +19,11 @@ const app = createApp(queue, bearerToken);
 
 await registerBullBoard(app, queue);
 
-app.listen({ port, host: "0.0.0.0" }).then(() => {
+try {
+  await app.listen({ port, host: "::" });
   app.log.info(`task-manager (dev) listening on port ${port}`);
   app.log.info(`Bull Board UI available at http://localhost:${port}${BULL_BOARD_BASE_PATH}`);
-});
+} catch (error) {
+  app.log.error(error);
+  process.exit(1);
+}

--- a/apps/task-manager/src/server.ts
+++ b/apps/task-manager/src/server.ts
@@ -11,6 +11,10 @@ if (!bearerToken) throw new Error("JOBS_API_BEARER_TOKEN is required");
 const queue = createQueue(redisUrl);
 const app = createApp(queue, bearerToken);
 
-app.listen({ port, host: "0.0.0.0" }).then(() => {
+try {
+  await app.listen({ port, host: "::" });
   app.log.info(`task-manager listening on port ${port}`);
-});
+} catch (error) {
+  app.log.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
Diagnosed the "localhost:3000 gives ERR_CONNECTION_RESET" report by reproducing locally (Docker Redis + `pnpm dev`) and found two compounding bugs that made the server's actual state impossible to observe or, on some systems, reach:

1. **Silent by default**: `Fastify()` with no options defaults to `logger: false`, so every `app.log.*` call — including the "listening on port" startup message — was a silent no-op. Confirmed: `tsx watch` produced zero stdout even on a fully successful start.
2. **IPv4-only bind**: `app.listen({ host: "0.0.0.0" })` only binds the IPv4 wildcard. Reproduced with curl: `127.0.0.1:3000` worked, `[::1]:3000` was refused. Many systems resolve `localhost` to `::1` first — depending on client fallback behavior this can surface as a failed/reset connection rather than transparently falling back to IPv4.

While reproducing, also found `app.listen(...).then(...)` had no `.catch()` — confirmed by starting a second instance on an already-bound port, which crashed with a raw, unhandled-rejection stack trace instead of a clear error.

**Follow-up bug found testing the fix**: once localhost was actually reachable, the Bull Board UI itself returned 401. It's mounted as a sibling `register()` on the same Fastify instance in `devServer.ts`, and Fastify hooks cascade into nested `register()` contexts — so it inherited the `/jobs` bearer-auth hook, which a plain browser tab can never satisfy (no way to attach an `Authorization` header on normal navigation). Moved the hook (and the three `/jobs` routes) into their own encapsulated plugin so it no longer leaks to sibling routes; `/jobs` stays protected exactly as before.

## Fix
- `Fastify({ logger: process.env.NODE_ENV !== "test" })` — enabled outside tests (vitest sets `NODE_ENV=test`, where per-request logs would just be noise).
- `host: "::"` instead of `"0.0.0.0"` — dual-stack, serves both `127.0.0.1` and `::1`.
- Wrapped `app.listen()` in try/catch with `app.log.error` + `process.exit(1)` in both `server.ts` and `devServer.ts`.
- `/jobs` routes + the bearer-auth hook now live in an encapsulated `app.register()` plugin instead of on the root `app`, so sibling routes (Bull Board) aren't auth-gated.

## Test plan
- [x] `pnpm --filter task-manager test` — 24/24 passing (added a regression test pinning that sibling routes on the returned `app` aren't auth-gated)
- [x] `tsc --noEmit` passes
- [x] Reproduced pre-fix: `curl http://127.0.0.1:3000` worked, `curl http://[::1]:3000` was refused, `tsx watch` produced no stdout at all
- [x] Reproduced pre-fix crash: starting a 2nd instance on the same port crashed with a raw unhandled-rejection trace
- [x] Verified post-fix: dev server now logs the startup/Bull Board lines; both `127.0.0.1:3000` and `[::1]:3000` respond correctly (201 on `POST /jobs`); posted jobs visible in Bull Board's queue counts
- [x] Verified the auth-scoping fix: `GET /admin/queues` and its API return 200 with no `Authorization` header; `POST /jobs` still 401s without one and works with it
