### PR TITLE
Build the Mac worker for apps/task-manager (#249)

### DIFF
--- a/apps/task-manager/README.md
+++ b/apps/task-manager/README.md
@@ -4,16 +4,43 @@ Jobs API server for the email → action-items automation (see [#248](https://gi
 Exposes the BullMQ + Redis queue over HTTP for `personal-assistant` to schedule action-item
 extraction jobs and poll their status/result.
 
-The Mac worker that actually processes jobs (colocated in this package per #245) is built
-separately in #249.
+The Mac worker that actually processes jobs (`src/worker.ts`, colocated in this package per #245,
+built in #249) consumes the same queue. It never runs on Dokku/CI — it's started locally on the
+user's Mac (via a LaunchAgent, see #243) and is the only thing that ever reads email content.
 
 ## Environment variables
+
+### Jobs API server (`server.ts` / `devServer.ts`)
 
 | Variable                | Required | Description                                              |
 | ------------------------ | -------- | ---------------------------------------------------------- |
 | `REDIS_URL`              | yes      | Connection string for the BullMQ-backing Redis instance    |
 | `JOBS_API_BEARER_TOKEN`  | yes      | Shared secret every request must present as `Authorization: Bearer <token>` |
 | `PORT`                   | no       | HTTP port to listen on (default `3000`)                    |
+
+### Mac worker (`worker.ts`)
+
+| Variable                 | Required | Description                                                                 |
+| ------------------------- | -------- | ----------------------------------------------------------------------------- |
+| `REDIS_URL`               | yes      | Same Redis instance as the Jobs API server                                    |
+| `GMAIL_CLIENT_ID`         | yes\*    | OAuth client id for the worker's `gmail.readonly` credential (#236)           |
+| `GMAIL_CLIENT_SECRET`     | yes\*    | OAuth client secret for the same credential                                   |
+| `GMAIL_KEYCHAIN_ACCOUNT`  | no       | macOS Keychain "account" to read the refresh token from (default `task-manager-worker`) |
+| `GMAIL_KEYCHAIN_SERVICE`  | no       | macOS Keychain "service" to read the refresh token from (default `gmail-refresh-token`) |
+| `LM_STUDIO_BASE_URL`      | no       | Base URL of the local LM Studio server (default `http://localhost:1234`)      |
+| `WORKER_FAKE_DEPS`        | no       | `"true"` swaps in canned fake Gmail/LM Studio implementations instead of the real ones — **manual smoke-testing only, never set in production** (see below) |
+
+\* not required when `WORKER_FAKE_DEPS=true`.
+
+The worker reads the Gmail refresh token from the **macOS Keychain** at startup by shelling out to
+the `security` CLI (`security find-generic-password -a <account> -s <service> -w`, see
+`src/keychain.ts`). **This is macOS-only** — there is no cross-platform Node API for the Keychain —
+and it has never been exercised against a real Keychain in this repo's CI or in the sandbox this
+worker was developed in, both of which are Linux. Likewise, the LM Studio HTTP call
+(`src/lmStudio.ts`) talks to a real local server that isn't running in CI/sandbox either. Both are
+built behind small seams (`EmailFetcher`, `ActionItemExtractor`) so `src/jobProcessor.ts` — the
+actual "handle one job" logic — is unit-tested with fakes, independent of Keychain/Gmail/LM Studio
+availability. See the PR that introduced this file for what was and wasn't verified end-to-end.
 
 ## Endpoints
 
@@ -76,3 +103,20 @@ pnpm --filter task-manager test
    ```bash
    pnpm --filter task-manager dev:redis:down
    ```
+
+### Running the worker locally
+
+With Redis up (`pnpm --filter task-manager dev:redis`), the worker can be run against real
+Gmail/LM Studio (macOS only) or, for smoke-testing the queue wiring itself anywhere (including this
+sandbox), against fakes:
+
+```bash
+# Real Gmail + LM Studio (macOS only — reads the refresh token from the Keychain)
+REDIS_URL=redis://localhost:6379 \
+GMAIL_CLIENT_ID=... GMAIL_CLIENT_SECRET=... \
+pnpm --filter task-manager worker
+
+# Fakes only — proves the Worker really consumes `extract-action-items` and returns
+# a real BullMQ result, without needing Keychain/Gmail/LM Studio
+REDIS_URL=redis://localhost:6379 WORKER_FAKE_DEPS=true pnpm --filter task-manager worker
+```

--- a/apps/task-manager/package.json
+++ b/apps/task-manager/package.json
@@ -6,6 +6,8 @@
     "dev": "tsx watch src/devServer.ts",
     "dev:redis": "docker compose up -d",
     "dev:redis:down": "docker compose down",
+    "worker": "tsx watch src/worker.ts",
+    "worker:start": "node dist/worker.js",
     "build": "tsc",
     "start": "node dist/server.js",
     "test": "vitest run"
@@ -13,6 +15,8 @@
   "dependencies": {
     "bullmq": "5.81.3",
     "fastify": "5.11.2",
+    "google-auth-library": "10.5.0",
+    "googleapis": "173.0.0",
     "ioredis": "5.11.1"
   },
   "devDependencies": {

--- a/apps/task-manager/src/actionItem.ts
+++ b/apps/task-manager/src/actionItem.ts
@@ -1,0 +1,19 @@
+// Shared job payload/result types for the `extract-action-items` queue.
+// `worker.ts` (this package's consumer) and `queue.ts`/`app.ts` (the producer/Jobs
+// API side) import these directly rather than duplicating the shape — see #241 for
+// the wire contract these mirror.
+
+export interface ActionItem {
+  title: string;
+  description: string;
+  dueDate: string | null;
+}
+
+export interface EmailJobPayload {
+  emailId: string;
+}
+
+export interface EmailJobResult {
+  emailId: string;
+  actionItems: ActionItem[];
+}

--- a/apps/task-manager/src/gmail.test.ts
+++ b/apps/task-manager/src/gmail.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { gmail_v1 } from "googleapis";
+import { parseGmailMessage } from "./gmail.js";
+
+function b64url(text: string): string {
+  return Buffer.from(text, "utf-8").toString("base64url");
+}
+
+function header(name: string, value: string): gmail_v1.Schema$MessagePartHeader {
+  return { name, value };
+}
+
+describe("parseGmailMessage", () => {
+  it("extracts id, subject, from, and a plain-text body", () => {
+    const message: gmail_v1.Schema$Message = {
+      id: "msg-1",
+      snippet: "fallback snippet",
+      payload: {
+        headers: [header("Subject", "Q3 planning"), header("From", "boss@example.com")],
+        mimeType: "text/plain",
+        body: { data: b64url("Please send the report by Friday.") },
+      },
+    };
+
+    expect(parseGmailMessage(message)).toEqual({
+      id: "msg-1",
+      subject: "Q3 planning",
+      from: "boss@example.com",
+      body: "Please send the report by Friday.",
+    });
+  });
+
+  it("picks the text/plain part out of a multipart message", () => {
+    const message: gmail_v1.Schema$Message = {
+      id: "msg-2",
+      payload: {
+        headers: [header("Subject", "Multipart"), header("From", "a@b.com")],
+        mimeType: "multipart/alternative",
+        parts: [
+          { mimeType: "text/html", body: { data: b64url("<p>hi</p>") } },
+          { mimeType: "text/plain", body: { data: b64url("hi in plain text") } },
+        ],
+      },
+    };
+
+    expect(parseGmailMessage(message).body).toBe("hi in plain text");
+  });
+
+  it("recurses into nested multipart parts to find plain text", () => {
+    const message: gmail_v1.Schema$Message = {
+      id: "msg-3",
+      payload: {
+        headers: [],
+        mimeType: "multipart/mixed",
+        parts: [
+          {
+            mimeType: "multipart/alternative",
+            parts: [{ mimeType: "text/plain", body: { data: b64url("nested body") } }],
+          },
+        ],
+      },
+    };
+
+    expect(parseGmailMessage(message).body).toBe("nested body");
+  });
+
+  it("falls back to the snippet when no text/plain part is found", () => {
+    const message: gmail_v1.Schema$Message = {
+      id: "msg-4",
+      snippet: "fallback snippet",
+      payload: {
+        headers: [],
+        mimeType: "text/html",
+        body: { data: b64url("<p>only html</p>") },
+      },
+    };
+
+    // The html-only body.data path isn't a text/plain match at the top level,
+    // and there's no `parts`, so extractBody falls through to `part.body?.data`.
+    // Only when *that's* also absent does the snippet kick in — cover both.
+    expect(parseGmailMessage(message).body).toBe("<p>only html</p>");
+
+    const withoutBody: gmail_v1.Schema$Message = {
+      id: "msg-5",
+      snippet: "fallback snippet",
+      payload: { headers: [], mimeType: "text/html" },
+    };
+    expect(parseGmailMessage(withoutBody).body).toBe("fallback snippet");
+  });
+
+  it("handles missing headers and payload gracefully", () => {
+    const message: gmail_v1.Schema$Message = { id: "msg-6" };
+
+    expect(parseGmailMessage(message)).toEqual({
+      id: "msg-6",
+      subject: "",
+      from: "",
+      body: "",
+    });
+  });
+});

--- a/apps/task-manager/src/gmail.ts
+++ b/apps/task-manager/src/gmail.ts
@@ -1,0 +1,90 @@
+// Gmail message fetch, scoped to `gmail.readonly`. Only ever runs on the Mac
+// worker (#249) — the orchestration service (#236) never imports this, it only
+// ever handles message IDs.
+import { OAuth2Client } from "google-auth-library";
+import { google, type gmail_v1 } from "googleapis";
+
+export interface EmailContent {
+  id: string;
+  subject: string;
+  from: string;
+  body: string;
+}
+
+export interface EmailFetcher {
+  fetchEmail(emailId: string): Promise<EmailContent>;
+}
+
+export interface GmailOAuthConfig {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+}
+
+// Real implementation — exchanges the refresh token (read from the macOS Keychain
+// by the caller, see keychain.ts) for an access token via google-auth-library, then
+// calls the Gmail API's messages.get endpoint via googleapis. This talks to real
+// Google infrastructure so it cannot be exercised in CI/sandbox; `parseGmailMessage`
+// below is the pure, unit-tested seam that covers the actual parsing logic.
+export function createGmailFetcher(config: GmailOAuthConfig): EmailFetcher {
+  const oauth2Client = new OAuth2Client({
+    clientId: config.clientId,
+    clientSecret: config.clientSecret,
+  });
+  oauth2Client.setCredentials({ refresh_token: config.refreshToken });
+
+  const gmail = google.gmail({ version: "v1", auth: oauth2Client });
+
+  return {
+    async fetchEmail(emailId: string): Promise<EmailContent> {
+      const { data } = await gmail.users.messages.get({
+        userId: "me",
+        id: emailId,
+        format: "full",
+      });
+      return parseGmailMessage(data);
+    },
+  };
+}
+
+function decodeBase64Url(data: string): string {
+  return Buffer.from(data, "base64url").toString("utf-8");
+}
+
+function findHeader(headers: gmail_v1.Schema$MessagePartHeader[] | undefined, name: string): string {
+  const header = headers?.find((h) => h.name?.toLowerCase() === name.toLowerCase());
+  return header?.value ?? "";
+}
+
+function extractBody(part: gmail_v1.Schema$MessagePart | undefined): string {
+  if (!part) return "";
+
+  if (part.mimeType === "text/plain" && part.body?.data) {
+    return decodeBase64Url(part.body.data);
+  }
+
+  if (part.parts) {
+    const plainPart = part.parts.find((p) => p.mimeType === "text/plain" && p.body?.data);
+    if (plainPart?.body?.data) return decodeBase64Url(plainPart.body.data);
+
+    for (const nested of part.parts) {
+      const body = extractBody(nested);
+      if (body) return body;
+    }
+  }
+
+  if (part.body?.data) return decodeBase64Url(part.body.data);
+
+  return "";
+}
+
+// Pure and independent of the googleapis client, so it's fully unit-testable
+// against hand-built `gmail_v1.Schema$Message` fixtures.
+export function parseGmailMessage(message: gmail_v1.Schema$Message): EmailContent {
+  return {
+    id: message.id ?? "",
+    subject: findHeader(message.payload?.headers, "subject"),
+    from: findHeader(message.payload?.headers, "from"),
+    body: extractBody(message.payload) || message.snippet || "",
+  };
+}

--- a/apps/task-manager/src/jobProcessor.test.ts
+++ b/apps/task-manager/src/jobProcessor.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { processEmailJob } from "./jobProcessor.js";
+import type { EmailContent, EmailFetcher } from "./gmail.js";
+import type { ActionItemExtractor } from "./lmStudio.js";
+import type { ActionItem } from "./actionItem.js";
+
+function fakeFetcher(email: EmailContent): EmailFetcher {
+  return {
+    async fetchEmail(emailId) {
+      expect(emailId).toBe(email.id);
+      return email;
+    },
+  };
+}
+
+function failingFetcher(error: Error): EmailFetcher {
+  return {
+    async fetchEmail() {
+      throw error;
+    },
+  };
+}
+
+function fakeExtractor(actionItems: ActionItem[]): ActionItemExtractor {
+  return {
+    async extract() {
+      return actionItems;
+    },
+  };
+}
+
+function failingExtractor(error: Error): ActionItemExtractor {
+  return {
+    async extract() {
+      throw error;
+    },
+  };
+}
+
+const EMAIL: EmailContent = {
+  id: "email-1",
+  subject: "Q3 planning",
+  from: "boss@example.com",
+  body: "Please send the report by Friday.",
+};
+
+const ACTION_ITEMS: ActionItem[] = [
+  { title: "Send the report", description: "Send the Q3 report", dueDate: "2026-08-08" },
+];
+
+describe("processEmailJob", () => {
+  it("fetches the email, extracts action items, and returns the job result shape", async () => {
+    const result = await processEmailJob("email-1", {
+      emailFetcher: fakeFetcher(EMAIL),
+      actionItemExtractor: fakeExtractor(ACTION_ITEMS),
+    });
+
+    expect(result).toEqual({ emailId: "email-1", actionItems: ACTION_ITEMS });
+  });
+
+  it("returns an empty actionItems array when none are found", async () => {
+    const result = await processEmailJob("email-1", {
+      emailFetcher: fakeFetcher(EMAIL),
+      actionItemExtractor: fakeExtractor([]),
+    });
+
+    expect(result).toEqual({ emailId: "email-1", actionItems: [] });
+  });
+
+  it("propagates an error when the email fetch fails, so BullMQ can mark the job failed", async () => {
+    const error = new Error("Gmail API error");
+
+    await expect(
+      processEmailJob("email-1", {
+        emailFetcher: failingFetcher(error),
+        actionItemExtractor: fakeExtractor(ACTION_ITEMS),
+      }),
+    ).rejects.toThrow("Gmail API error");
+  });
+
+  it("propagates an error when extraction fails, so BullMQ can mark the job failed", async () => {
+    const error = new Error("LM Studio error");
+
+    await expect(
+      processEmailJob("email-1", {
+        emailFetcher: fakeFetcher(EMAIL),
+        actionItemExtractor: failingExtractor(error),
+      }),
+    ).rejects.toThrow("LM Studio error");
+  });
+});

--- a/apps/task-manager/src/jobProcessor.ts
+++ b/apps/task-manager/src/jobProcessor.ts
@@ -1,0 +1,23 @@
+// The actual "handle one job" logic, independent of BullMQ. `worker.ts` wraps this
+// in a `Worker` processor callback; tests call it directly with fake dependencies so
+// the success/failure paths can be verified without a real Keychain, Gmail, or LM
+// Studio in the loop.
+import type { EmailJobResult } from "./actionItem.js";
+import type { EmailFetcher } from "./gmail.js";
+import type { ActionItemExtractor } from "./lmStudio.js";
+
+export interface JobProcessorDeps {
+  emailFetcher: EmailFetcher;
+  actionItemExtractor: ActionItemExtractor;
+}
+
+// Throws on any failure (email fetch or extraction) so BullMQ marks the job
+// `failed` with that error as `failedReason` — matching the Jobs API contract.
+export async function processEmailJob(
+  emailId: string,
+  deps: JobProcessorDeps,
+): Promise<EmailJobResult> {
+  const email = await deps.emailFetcher.fetchEmail(emailId);
+  const actionItems = await deps.actionItemExtractor.extract(email);
+  return { emailId, actionItems };
+}

--- a/apps/task-manager/src/keychain.test.ts
+++ b/apps/task-manager/src/keychain.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const execFileMock = vi.fn();
+
+// The `security` CLI only exists on macOS — this repo's CI and sandbox are Linux,
+// so the real keychain read is unverifiable here (see keychain.ts's header comment).
+// This test only pins down that we shell out with the right arguments and parse
+// stdout correctly; it can't prove the real macOS binary behaves this way.
+vi.mock("node:child_process", () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+}));
+
+beforeEach(() => {
+  execFileMock.mockReset();
+});
+
+describe("macKeychainReader", () => {
+  it("shells out to `security find-generic-password` with the given account/service", async () => {
+    execFileMock.mockImplementation(
+      (
+        _cmd: string,
+        _args: string[],
+        callback: (error: unknown, result: { stdout: string; stderr: string }) => void,
+      ) => {
+        callback(null, { stdout: "refresh-token-value\n", stderr: "" });
+      },
+    );
+
+    const { macKeychainReader } = await import("./keychain.js");
+    const token = await macKeychainReader.read("worker-account", "gmail-refresh-token");
+
+    expect(token).toBe("refresh-token-value");
+    expect(execFileMock).toHaveBeenCalledWith(
+      "security",
+      ["find-generic-password", "-a", "worker-account", "-s", "gmail-refresh-token", "-w"],
+      expect.any(Function),
+    );
+  });
+
+  it("propagates an error when the keychain read fails", async () => {
+    execFileMock.mockImplementation(
+      (
+        _cmd: string,
+        _args: string[],
+        callback: (error: unknown, result: { stdout: string; stderr: string }) => void,
+      ) => {
+        callback(new Error("security: item not found"), { stdout: "", stderr: "not found" });
+      },
+    );
+
+    const { macKeychainReader } = await import("./keychain.js");
+
+    await expect(macKeychainReader.read("worker-account", "gmail-refresh-token")).rejects.toThrow(
+      "security: item not found",
+    );
+  });
+});

--- a/apps/task-manager/src/keychain.ts
+++ b/apps/task-manager/src/keychain.ts
@@ -1,0 +1,31 @@
+// Reads the Gmail refresh token from the macOS Keychain at worker startup (#236).
+// This worker only ever runs on the user's Mac, so shelling out to the `security`
+// CLI is the only way to reach it from Node — there is no cross-platform API.
+//
+// macOS-only, unverified in CI/sandbox: this repo's CI and the sandbox this was
+// developed in are both Linux, where `security` does not exist, so the real
+// keychain read path has never actually executed end-to-end. `KeychainReader` is
+// the seam that lets the rest of the worker (and its tests) stay independent of
+// that fact — tests inject a fake reader instead of shelling out.
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface KeychainReader {
+  read(account: string, service: string): Promise<string>;
+}
+
+export const macKeychainReader: KeychainReader = {
+  async read(account: string, service: string): Promise<string> {
+    const { stdout } = await execFileAsync("security", [
+      "find-generic-password",
+      "-a",
+      account,
+      "-s",
+      service,
+      "-w",
+    ]);
+    return stdout.trim();
+  },
+};

--- a/apps/task-manager/src/lmStudio.test.ts
+++ b/apps/task-manager/src/lmStudio.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+import { createLmStudioExtractor } from "./lmStudio.js";
+import type { EmailContent } from "./gmail.js";
+
+// LM Studio is a real local server (localhost:1234) — nothing to talk to in
+// CI/sandbox, so every test here injects a fake `fetch` via the `fetchImpl` seam
+// rather than making a real HTTP call (see lmStudio.ts's LmStudioConfig comment).
+
+const EMAIL: EmailContent = {
+  id: "email-1",
+  subject: "Q3 planning",
+  from: "boss@example.com",
+  body: "Please send the report by Friday.",
+};
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    json: async () => body,
+  } as Response;
+}
+
+describe("createLmStudioExtractor", () => {
+  it("queries /v1/models for the loaded model id, then posts a structured chat completion request", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const urlString = String(url);
+      if (urlString.endsWith("/v1/models")) {
+        return jsonResponse({ data: [{ id: "some-loaded-model" }] });
+      }
+      if (urlString.endsWith("/v1/chat/completions")) {
+        const requestBody = JSON.parse(String(init?.body));
+        expect(requestBody.model).toBe("some-loaded-model");
+        expect(requestBody.response_format.type).toBe("json_schema");
+        expect(requestBody.messages[1].content).toContain("Please send the report by Friday.");
+
+        return jsonResponse({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  actionItems: [
+                    { title: "Send the report", description: "Send the Q3 report", dueDate: null },
+                  ],
+                }),
+              },
+            },
+          ],
+        });
+      }
+      throw new Error(`Unexpected URL: ${urlString}`);
+    });
+
+    const extractor = createLmStudioExtractor({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    const actionItems = await extractor.extract(EMAIL);
+
+    expect(actionItems).toEqual([
+      { title: "Send the report", description: "Send the Q3 report", dueDate: null },
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns an empty array when the model reports no action items", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      if (String(url).endsWith("/v1/models")) return jsonResponse({ data: [{ id: "m" }] });
+      return jsonResponse({ choices: [{ message: { content: JSON.stringify({ actionItems: [] }) } }] });
+    });
+
+    const extractor = createLmStudioExtractor({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(await extractor.extract(EMAIL)).toEqual([]);
+  });
+
+  it("throws when no model is currently loaded in LM Studio", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ data: [] }));
+
+    const extractor = createLmStudioExtractor({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    await expect(extractor.extract(EMAIL)).rejects.toThrow("no model currently loaded");
+  });
+
+  it("throws when the /v1/models request fails", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}, false, 500));
+
+    const extractor = createLmStudioExtractor({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    await expect(extractor.extract(EMAIL)).rejects.toThrow("/v1/models request failed");
+  });
+
+  it("throws when the chat completion request fails", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      if (String(url).endsWith("/v1/models")) return jsonResponse({ data: [{ id: "m" }] });
+      return jsonResponse({}, false, 503);
+    });
+
+    const extractor = createLmStudioExtractor({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    await expect(extractor.extract(EMAIL)).rejects.toThrow("/v1/chat/completions request failed");
+  });
+
+  it("throws when the response content is not valid JSON", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      if (String(url).endsWith("/v1/models")) return jsonResponse({ data: [{ id: "m" }] });
+      return jsonResponse({ choices: [{ message: { content: "not json" } }] });
+    });
+
+    const extractor = createLmStudioExtractor({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    await expect(extractor.extract(EMAIL)).rejects.toThrow("not valid JSON");
+  });
+
+  it("throws when the response is missing an actionItems array", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      if (String(url).endsWith("/v1/models")) return jsonResponse({ data: [{ id: "m" }] });
+      return jsonResponse({ choices: [{ message: { content: JSON.stringify({ foo: "bar" }) } }] });
+    });
+
+    const extractor = createLmStudioExtractor({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    await expect(extractor.extract(EMAIL)).rejects.toThrow("missing an actionItems array");
+  });
+
+  it("defaults to http://localhost:1234 as the base URL", async () => {
+    const fetchImpl = vi.fn(async (url: string | URL) => {
+      if (String(url).endsWith("/v1/models")) return jsonResponse({ data: [{ id: "m" }] });
+      return jsonResponse({ choices: [{ message: { content: JSON.stringify({ actionItems: [] }) } }] });
+    });
+
+    const extractor = createLmStudioExtractor({ fetchImpl: fetchImpl as unknown as typeof fetch });
+    await extractor.extract(EMAIL);
+
+    expect(String(fetchImpl.mock.calls[0][0])).toBe("http://localhost:1234/v1/models");
+  });
+});

--- a/apps/task-manager/src/lmStudio.ts
+++ b/apps/task-manager/src/lmStudio.ts
@@ -1,0 +1,134 @@
+// Calls LM Studio's local OpenAI-compatible server to extract action items from
+// an email (#238). Never leaves the Mac — `baseUrl` defaults to localhost, and this
+// is the only model call the worker makes. Uses the platform `fetch` (Node 22) with
+// no extra HTTP/SDK dependency, since LM Studio's API surface here is small.
+import type { ActionItem } from "./actionItem.js";
+import type { EmailContent } from "./gmail.js";
+
+export interface ActionItemExtractor {
+  extract(email: EmailContent): Promise<ActionItem[]>;
+}
+
+export interface LmStudioConfig {
+  baseUrl?: string;
+  // Test seam — a fake `fetch` swapped in so the request/response shape can be
+  // asserted without a real LM Studio server running (this can't be exercised for
+  // real in CI/sandbox, there is no LM Studio instance to talk to).
+  fetchImpl?: typeof fetch;
+}
+
+const actionItemsJsonSchema = {
+  type: "object",
+  properties: {
+    actionItems: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          description: { type: "string" },
+          dueDate: { type: ["string", "null"] },
+        },
+        required: ["title", "description", "dueDate"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["actionItems"],
+  additionalProperties: false,
+} as const;
+
+interface LmStudioModelsResponse {
+  data?: Array<{ id?: string }>;
+}
+
+interface LmStudioChatCompletionResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+async function getLoadedModelId(baseUrl: string, fetchImpl: typeof fetch): Promise<string> {
+  const response = await fetchImpl(`${baseUrl}/v1/models`);
+  if (!response.ok) {
+    throw new Error(`LM Studio /v1/models request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const body = (await response.json()) as LmStudioModelsResponse;
+  const modelId = body.data?.[0]?.id;
+  if (!modelId) {
+    throw new Error("LM Studio has no model currently loaded");
+  }
+  return modelId;
+}
+
+function buildPrompt(email: EmailContent): string {
+  return [
+    `Subject: ${email.subject}`,
+    `From: ${email.from}`,
+    "",
+    email.body,
+  ].join("\n");
+}
+
+function parseActionItems(response: LmStudioChatCompletionResponse): ActionItem[] {
+  const content = response.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new Error("LM Studio response contained no message content");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (cause) {
+    throw new Error("LM Studio response content was not valid JSON", { cause });
+  }
+
+  const actionItems = (parsed as { actionItems?: unknown }).actionItems;
+  if (!Array.isArray(actionItems)) {
+    throw new Error("LM Studio response was missing an actionItems array");
+  }
+
+  return actionItems as ActionItem[];
+}
+
+export function createLmStudioExtractor(config: LmStudioConfig = {}): ActionItemExtractor {
+  const baseUrl = config.baseUrl ?? "http://localhost:1234";
+  const fetchImpl = config.fetchImpl ?? fetch;
+
+  return {
+    async extract(email: EmailContent): Promise<ActionItem[]> {
+      const model = await getLoadedModelId(baseUrl, fetchImpl);
+
+      const response = await fetchImpl(`${baseUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model,
+          messages: [
+            {
+              role: "system",
+              content:
+                "Extract action items from the email below. Respond only with the requested JSON shape. If there are no action items, return an empty array.",
+            },
+            { role: "user", content: buildPrompt(email) },
+          ],
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "action_items",
+              schema: actionItemsJsonSchema,
+            },
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `LM Studio /v1/chat/completions request failed: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const body = (await response.json()) as LmStudioChatCompletionResponse;
+      return parseActionItems(body);
+    },
+  };
+}

--- a/apps/task-manager/src/worker.ts
+++ b/apps/task-manager/src/worker.ts
@@ -1,0 +1,103 @@
+// Mac worker entry point (#249). Separate from `server.ts`/`devServer.ts` — this is
+// never deployed to Dokku, it only ever runs on the user's Mac via a LaunchAgent
+// (#243), colocated here so it can share the `EmailJobPayload`/`EmailJobResult`/
+// `ActionItem` types and `QUEUE_NAME` with the Jobs API server directly via import.
+//
+// Consumes the `extract-action-items` queue: for each job, fetches the email via
+// the worker's own `gmail.readonly` credential (refresh token read from the macOS
+// Keychain, see keychain.ts), extracts action items via a local LM Studio server
+// (see lmStudio.ts), and returns `{ emailId, actionItems }` as the job result — or
+// lets the error propagate so BullMQ marks the job `failed`.
+import { Worker } from "bullmq";
+import { Redis } from "ioredis";
+import type { EmailJobPayload, EmailJobResult } from "./actionItem.js";
+import { createGmailFetcher, type EmailFetcher } from "./gmail.js";
+import { macKeychainReader } from "./keychain.js";
+import { createLmStudioExtractor, type ActionItemExtractor } from "./lmStudio.js";
+import { processEmailJob } from "./jobProcessor.js";
+import { QUEUE_NAME } from "./queue.js";
+
+const redisUrl = process.env.REDIS_URL;
+if (!redisUrl) throw new Error("REDIS_URL is required");
+
+const lmStudioBaseUrl = process.env.LM_STUDIO_BASE_URL ?? "http://localhost:1234";
+const keychainAccount = process.env.GMAIL_KEYCHAIN_ACCOUNT ?? "task-manager-worker";
+const keychainService = process.env.GMAIL_KEYCHAIN_SERVICE ?? "gmail-refresh-token";
+
+// Escape hatch for manual smoke-testing against a real Redis/BullMQ queue in
+// environments without macOS Keychain or a running LM Studio (e.g. this repo's
+// Linux CI/sandbox) — swaps in canned, deterministic fakes instead of the real
+// Gmail/LM Studio integrations. Never set in production; the LaunchAgent plist
+// (#243) must not set this variable.
+const useFakeDeps = process.env.WORKER_FAKE_DEPS === "true";
+
+async function buildDependencies(): Promise<{
+  emailFetcher: EmailFetcher;
+  actionItemExtractor: ActionItemExtractor;
+}> {
+  if (useFakeDeps) {
+    return {
+      emailFetcher: {
+        async fetchEmail(emailId) {
+          // Also exercises the failure path in manual smoke tests: a real Gmail
+          // fetch error would propagate the same way and BullMQ would mark the
+          // job `failed` with it as `failedReason`.
+          if (emailId === "trigger-fake-failure") {
+            throw new Error("[fake] simulated Gmail fetch failure");
+          }
+          return {
+            id: emailId,
+            subject: "[fake] Q3 planning",
+            from: "fake@example.com",
+            body: "Please send the report by Friday.",
+          };
+        },
+      },
+      actionItemExtractor: {
+        async extract() {
+          return [
+            {
+              title: "Send the report",
+              description: "Send the Q3 report as requested",
+              dueDate: null,
+            },
+          ];
+        },
+      },
+    };
+  }
+
+  const gmailClientId = process.env.GMAIL_CLIENT_ID;
+  const gmailClientSecret = process.env.GMAIL_CLIENT_SECRET;
+  if (!gmailClientId) throw new Error("GMAIL_CLIENT_ID is required");
+  if (!gmailClientSecret) throw new Error("GMAIL_CLIENT_SECRET is required");
+
+  const refreshToken = await macKeychainReader.read(keychainAccount, keychainService);
+
+  return {
+    emailFetcher: createGmailFetcher({
+      clientId: gmailClientId,
+      clientSecret: gmailClientSecret,
+      refreshToken,
+    }),
+    actionItemExtractor: createLmStudioExtractor({ baseUrl: lmStudioBaseUrl }),
+  };
+}
+
+const { emailFetcher, actionItemExtractor } = await buildDependencies();
+
+const connection = new Redis(redisUrl, { maxRetriesPerRequest: null });
+
+const worker = new Worker<EmailJobPayload, EmailJobResult>(
+  QUEUE_NAME,
+  async (job) => processEmailJob(job.data.emailId, { emailFetcher, actionItemExtractor }),
+  { connection },
+);
+
+worker.on("ready", () => {
+  console.log(`task-manager worker ready, consuming queue "${QUEUE_NAME}"`);
+});
+
+worker.on("failed", (job, error) => {
+  console.error(`Job ${job?.id ?? "<unknown>"} failed:`, error);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,12 @@ importers:
       fastify:
         specifier: 5.11.2
         version: 5.11.2
+      google-auth-library:
+        specifier: 10.5.0
+        version: 10.5.0
+      googleapis:
+        specifier: 173.0.0
+        version: 173.0.0
       ioredis:
         specifier: 5.11.1
         version: 5.11.1
@@ -738,6 +744,10 @@ packages:
   '@ioredis/commands@1.10.0':
     resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -799,6 +809,10 @@ packages:
 
   '@pixi/colord@2.9.6':
     resolution: {integrity: sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@playwright/test@1.62.1':
     resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
@@ -1237,6 +1251,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
@@ -1265,9 +1283,17 @@ packages:
     resolution: {integrity: sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==}
     hasBin: true
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -1328,16 +1354,31 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   bullmq@5.81.3:
     resolution: {integrity: sha512-Q7uEH2G92rVjX3Yl2qw3+6VEO15uxehC6DfeTHQBQTehddcRDSDuquD9zuvDjxiCffXsPUaBwrRlvlbVcgKs7g==}
@@ -1347,6 +1388,14 @@ packages:
     peerDependenciesMeta:
       redis:
         optional: true
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1394,6 +1443,13 @@ packages:
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -1428,6 +1484,10 @@ packages:
     engines: {node: '>=12.0.0'}
     deprecated: v4 is no longer maintained, upgrade to v5
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
@@ -1452,6 +1512,10 @@ packages:
 
   dat.gui@0.7.9:
     resolution: {integrity: sha512-sCNc1OHobc+Erc1HqiswYgHdVNpSJUlk/Hz8vzOCsER7rl+oF/4+v8GXFUyCgtXpoCX6+bnmg07DedLvBLwYKQ==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   debounce@3.0.0:
     resolution: {integrity: sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==}
@@ -1522,8 +1586,18 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   earcut@3.2.3:
     resolution: {integrity: sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ejs@6.0.1:
     resolution: {integrity: sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==}
@@ -1536,6 +1610,12 @@ packages:
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -1544,8 +1624,20 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -1658,6 +1750,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   find-my-way@9.7.0:
     resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
@@ -1673,6 +1769,14 @@ packages:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1683,6 +1787,21 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@7.1.3:
+    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
+
+  gaxios@7.3.0:
+    resolution: {integrity: sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.4:
+    resolution: {integrity: sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==}
+    engines: {node: '>=18'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -1690,6 +1809,14 @@ packages:
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@5.0.0-beta.4:
     resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
@@ -1701,12 +1828,53 @@ packages:
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  google-auth-library@10.5.0:
+    resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@1.2.0:
+    resolution: {integrity: sha512-WE9av4wKDZgRjBwgVUabocx8T6/7o3Ca1Fat46FXDhXVAFibzNadedcOXrdgd1Kzmk8tsk/9ZH89Wyf/SqeZ3A==}
+    engines: {node: '>=18'}
+
+  googleapis-common@8.0.3:
+    resolution: {integrity: sha512-7g1yzQKx0mmNTjiK0H9dJ8eqKqDBveES9vLHeg5neb3BMQy/d1oQefIMhIpOVT8a+f+LOcixMEdRbFIW/cQUJw==}
+    engines: {node: '>=18'}
+
+  googleapis@173.0.0:
+    resolution: {integrity: sha512-xEJJYLZ4qeenVyfzispNfRjCe9bsv7CzBv5zYFLvScOze9snJ8S9W6hjQ729CWPQt5mvn/JrcRaCHzQiukt0ng==}
+    engines: {node: '>=18'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
+
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
@@ -1761,6 +1929,10 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -1792,6 +1964,10 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
@@ -1802,8 +1978,14 @@ packages:
   is-unsafe@1.0.1:
     resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   ismobilejs@1.1.1:
     resolution: {integrity: sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   js-binary-schema-parser@2.0.3:
     resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
@@ -1811,6 +1993,9 @@ packages:
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-schema-ref-resolver@3.0.0:
     resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
@@ -1823,6 +2008,12 @@ packages:
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -1911,6 +2102,9 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
@@ -1934,6 +2128,10 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
@@ -2109,6 +2307,10 @@ packages:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2145,8 +2347,17 @@ packages:
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
@@ -2161,6 +2372,10 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
@@ -2194,6 +2409,9 @@ packages:
     resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
     engines: {node: '>=20'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
@@ -2215,6 +2433,14 @@ packages:
   path-expression-matcher@1.6.1:
     resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==}
     engines: {node: '>=14.0.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -2290,6 +2516,10 @@ packages:
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -2410,6 +2640,10 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2419,6 +2653,9 @@ packages:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-regex2@5.1.1:
     resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
@@ -2458,12 +2695,40 @@ packages:
       '@types/node':
         optional: true
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   shiki@4.3.1:
     resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
     engines: {node: '>=20'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -2511,6 +2776,14 @@ packages:
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -2521,6 +2794,10 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
@@ -2721,6 +2998,9 @@ packages:
         optional: true
       uploadthing:
         optional: true
+
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -2934,10 +3214,27 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
@@ -3552,6 +3849,15 @@ snapshots:
 
   '@ioredis/commands@1.10.0': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@lukeed/ms@2.0.2': {}
@@ -3627,6 +3933,9 @@ snapshots:
   '@pinojs/redact@0.4.0': {}
 
   '@pixi/colord@2.9.6': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@playwright/test@1.62.1':
     dependencies:
@@ -3981,6 +4290,8 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -4004,7 +4315,13 @@ snapshots:
     dependencies:
       process-ancestry: 0.1.0
 
+  ansi-regex@5.0.1: {}
+
   ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
 
   ansi-styles@6.2.3: {}
 
@@ -4138,13 +4455,25 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
+  bignumber.js@9.3.1: {}
+
   boolbase@1.0.0: {}
+
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
+
+  buffer-equal-constant-time@1.0.1: {}
 
   bullmq@5.81.3:
     dependencies:
@@ -4156,6 +4485,16 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   ccount@2.0.1: {}
 
@@ -4191,6 +4530,12 @@ snapshots:
 
   collapse-white-space@2.1.0: {}
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
@@ -4210,6 +4555,12 @@ snapshots:
   cron-parser@4.9.0:
     dependencies:
       luxon: 3.7.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   crossws@0.3.5:
     dependencies:
@@ -4240,6 +4591,8 @@ snapshots:
       css-tree: 2.2.1
 
   dat.gui@0.7.9: {}
+
+  data-uri-to-buffer@4.0.1: {}
 
   debounce@3.0.0: {}
 
@@ -4293,7 +4646,19 @@ snapshots:
 
   dset@3.1.4: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   earcut@3.2.3: {}
+
+  eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ejs@6.0.1: {}
 
@@ -4304,11 +4669,23 @@ snapshots:
 
   emoji-regex@10.6.0: {}
 
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
   entities@4.5.0: {}
 
   entities@6.0.1: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.3.1: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -4475,6 +4852,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4491,15 +4873,69 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fsevents@2.3.2:
     optional: true
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
+  gaxios@7.1.3:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  gaxios@7.3.0:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.4:
+    dependencies:
+      gaxios: 7.1.3
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-tsconfig@5.0.0-beta.4:
     dependencies:
@@ -4511,11 +4947,63 @@ snapshots:
 
   github-slugger@2.0.0: {}
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.6
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  google-auth-library@10.5.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.0
+      gcp-metadata: 8.1.4
+      google-logging-utils: 1.2.0
+      gtoken: 8.0.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  google-logging-utils@1.2.0: {}
+
+  googleapis-common@8.0.3:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 7.1.3
+      google-auth-library: 10.5.0
+      google-logging-utils: 1.1.3
+      qs: 6.15.3
+      url-template: 2.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  googleapis@173.0.0:
+    dependencies:
+      google-auth-library: 10.5.0
+      googleapis-common: 8.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  gopd@1.2.0: {}
+
+  gtoken@8.0.0:
+    dependencies:
+      gaxios: 7.3.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   h3@1.15.11:
     dependencies:
@@ -4528,6 +5016,12 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.4
       uncrypto: 0.1.3
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-from-html@2.0.3:
     dependencies:
@@ -4673,6 +5167,13 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
@@ -4704,19 +5205,33 @@ snapshots:
 
   is-docker@4.0.0: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-hexadecimal@2.0.1: {}
 
   is-plain-obj@4.1.0: {}
 
   is-unsafe@1.0.1: {}
 
+  isexe@2.0.0: {}
+
   ismobilejs@1.1.1: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   js-binary-schema-parser@2.0.3: {}
 
   js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
 
   json-schema-ref-resolver@3.0.0:
     dependencies:
@@ -4727,6 +5242,17 @@ snapshots:
   jsonc-parser@2.3.1: {}
 
   jsonc-parser@3.3.1: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   kleur@4.1.5: {}
 
@@ -4789,6 +5315,8 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.5.2: {}
 
   luxon@3.7.2: {}
@@ -4810,6 +5338,8 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  math-intrinsics@1.1.0: {}
 
   mdast-util-definitions@6.0.0:
     dependencies:
@@ -5258,6 +5788,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.9
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.4
+
   minipass@7.1.3: {}
 
   mrmime@2.0.1: {}
@@ -5292,7 +5826,15 @@ snapshots:
 
   node-abort-controller@3.1.1: {}
 
+  node-domexception@1.0.0: {}
+
   node-fetch-native@1.6.7: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
@@ -5306,6 +5848,8 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  object-inspect@1.13.4: {}
 
   obug@2.1.4: {}
 
@@ -5338,6 +5882,8 @@ snapshots:
 
   p-timeout@7.0.1: {}
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@1.8.0: {}
 
   parse-entities@4.0.2:
@@ -5368,6 +5914,13 @@ snapshots:
   path-browserify@1.0.1: {}
 
   path-expression-matcher@1.6.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -5446,6 +5999,11 @@ snapshots:
   process-warning@5.1.0: {}
 
   property-information@7.2.0: {}
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   quick-format-unescaped@4.0.4: {}
 
@@ -5615,6 +6173,10 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.5.0
+
   rolldown@1.1.5:
     dependencies:
       '@oxc-project/types': 0.139.0
@@ -5667,6 +6229,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
     optional: true
+
+  safe-buffer@5.2.1: {}
 
   safe-regex2@5.1.1:
     dependencies:
@@ -5735,6 +6299,12 @@ snapshots:
       '@types/node': 24.13.3
     optional: true
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   shiki@4.3.1:
     dependencies:
       '@shikijs/core': 4.3.1
@@ -5746,7 +6316,37 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
 
@@ -5781,6 +6381,18 @@ snapshots:
 
   stream-replace-string@2.0.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
@@ -5796,6 +6408,10 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-ansi@7.2.0:
     dependencies:
@@ -5965,6 +6581,8 @@ snapshots:
       ufo: 1.6.4
     optionalDependencies:
       ioredis: 5.11.1
+
+  url-template@2.0.8: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -6136,10 +6754,28 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  web-streams-polyfill@3.3.3: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrap-ansi@9.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `apps/task-manager/src/worker.ts` — the Mac worker entry point (#249), a
  BullMQ `Worker` consuming the `extract-action-items` queue defined in `queue.ts`.
  Separate from `server.ts`/`devServer.ts` (never imported by either), colocated
  per #245 so it shares `EmailJobPayload`/`EmailJobResult`/`ActionItem`
  (`src/actionItem.ts`) and `QUEUE_NAME` directly via import.
- On each `{ emailId }` job:
  1. `src/gmail.ts` — fetches the full message via the worker's own
     `gmail.readonly` credential. The refresh token is read from the **macOS
     Keychain** at startup (`src/keychain.ts`, shells out to
     `security find-generic-password -a <account> -s <service> -w` — there is no
     other way to reach Keychain from Node), then exchanged for an access token
     via `google-auth-library`'s `OAuth2Client` and used to call the Gmail API
     (`googleapis`, `gmail.users.messages.get`).
  2. `src/lmStudio.ts` — queries LM Studio's `/v1/models` for whichever model is
     currently loaded (never hardcoded/requested-to-load), then calls
     `/v1/chat/completions` with `response_format.json_schema` for the
     `{ title, description, dueDate }[]` shape. Plain `fetch`, no SDK — LM
     Studio's surface here is small enough not to warrant one.
  3. `src/jobProcessor.ts` — `processEmailJob` composes the two into
     `{ emailId, actionItems }` on success, or lets the error propagate so
     BullMQ marks the job `failed` (`job.failedReason`), matching the Jobs API
     contract in #241/`app.ts`.
- New deps: `googleapis@173.0.0`, `google-auth-library@10.5.0` (pinned to the
  exact version `googleapis@173.0.0` bundles internally — a newer
  `google-auth-library` on its own caused a `tsc` type conflict from two
  structurally-different `OAuth2Client` declarations coexisting in
  `node_modules`; pinning to match dedupes them). Both are pure JS, no native
  compilation. Reused the existing `bullmq@5.81.3`/`ioredis@5.11.1` pins rather
  than introducing a second pair.
- `WORKER_FAKE_DEPS=true` escape hatch in `worker.ts`: swaps in canned
  Gmail/LM Studio fakes instead of the real integrations, for manually
  smoke-testing the queue wiring anywhere without Keychain/LM Studio available
  (see Test plan). Never set in production — documented as such in the README
  and in the code.
- README updated with the worker's env vars and a "running the worker locally"
  section (real vs. `WORKER_FAKE_DEPS`).

## What could and couldn't be verified
- **Verified for real**: brought up the compose Redis
  (`apps/task-manager/docker-compose.yml`), built the package, and ran the
  actual compiled `worker.js` as a standalone process against it with
  `WORKER_FAKE_DEPS=true`. Pushed a real job onto the real `extract-action-items`
  BullMQ queue from a separate script and confirmed the running `Worker`
  instance picked it up and returned `{ emailId, actionItems }` as
  `job.returnvalue` via BullMQ's normal `completed` flow — not a `vitest` mock,
  an actual second process talking to the worker over Redis. Also verified the
  failure path the same way: a job whose fake fetcher throws ends up `failed`
  with that error as `job.failedReason`, exactly as the Jobs API's `error`
  field expects.
- **Not verified, and can't be in this sandbox**: the real macOS Keychain read
  (`security` CLI doesn't exist on Linux) and the real LM Studio HTTP calls (no
  LM Studio instance running here) and the real Gmail API calls. Both are
  isolated behind seams (`KeychainReader`, `EmailFetcher`,
  `ActionItemExtractor`) so `jobProcessor.ts` — the logic that actually matters
  for BullMQ correctness — is unit-tested independent of them. `gmail.ts`'s
  message-parsing logic (`parseGmailMessage`, header lookup, multipart/nested
  body extraction, snippet fallback) is pure and unit-tested directly against
  hand-built `gmail_v1.Schema$Message` fixtures; only the thin `googleapis`
  wiring around it (`createGmailFetcher`) is unverified.

## Test plan
- [x] `pnpm --filter task-manager test` — 43/43 passing (24 existing + 19 new:
      `jobProcessor.test.ts`, `gmail.test.ts`, `keychain.test.ts`,
      `lmStudio.test.ts`)
- [x] `tsc --noEmit` passes
- [x] `pnpm --filter task-manager build` succeeds; `dist/` contains no `.test.js`
      files, `dist/worker.js` is present
- [x] Real end-to-end smoke test: `docker compose up -d` (compose Redis) →
      `REDIS_URL=... WORKER_FAKE_DEPS=true node dist/worker.js` → pushed a real
      job via a throwaway script using the package's own `createQueue` →
      confirmed the running worker consumed it and BullMQ reported `completed`
      with the correct result shape; repeated with a job designed to fail and
      confirmed BullMQ reported `failed` with the thrown error as
      `failedReason`
- [ ] Real Keychain read — can't verify outside macOS
- [ ] Real LM Studio call — can't verify without a running LM Studio instance
- [ ] Real Gmail API call — can't verify without live OAuth credentials

Closes #249
