### PR TITLE
Set up macOS LaunchAgent for the Mac worker (#251)

### DIFF
--- a/apps/task-manager/README.md
+++ b/apps/task-manager/README.md
@@ -120,3 +120,95 @@ pnpm --filter task-manager worker
 # a real BullMQ result, without needing Keychain/Gmail/LM Studio
 REDIS_URL=redis://localhost:6379 WORKER_FAKE_DEPS=true pnpm --filter task-manager worker
 ```
+
+## macOS LaunchAgent (#251)
+
+In normal use the worker isn't run by hand (`pnpm --filter task-manager worker`) — it runs as a
+user [LaunchAgent](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html)
+so it starts automatically at login and restarts itself if it crashes. The template plist lives at
+[`launchd/com.ertrzyiks.task-manager-worker.plist`](./launchd/com.ertrzyiks.task-manager-worker.plist):
+
+- `RunAtLoad = true` — starts the worker when you log in (or as soon as the agent is loaded).
+- `KeepAlive = true` — launchd restarts the worker if it exits for any reason, including a crash
+  (subject to launchd's default crash-loop throttling if it keeps failing immediately).
+- `ProgramArguments` runs the **built** `dist/worker.js` via `node` directly — not
+  `pnpm run worker` (that runs `tsx watch src/worker.ts`, the dev-only entrypoint) — matching how
+  the Jobs API server's `start` script runs `dist/server.js` rather than a dev script.
+- LM Studio itself (starting it, keeping a model loaded) is **not** managed by this LaunchAgent —
+  that stays your manual responsibility; the worker just calls whatever LM Studio has loaded at
+  the time (`src/lmStudio.ts`).
+
+### 1. Store the Gmail refresh token in the Keychain
+
+The worker reads the refresh token from the Keychain at startup (`src/keychain.ts`) instead of a
+plaintext file or env var. Get the refresh token first (see
+[`scripts/gmail-oauth/README.md`](../../scripts/gmail-oauth/README.md), #247), then store it under
+the exact account/service `keychain.ts` reads by default (`GMAIL_KEYCHAIN_ACCOUNT` /
+`GMAIL_KEYCHAIN_SERVICE`, default `task-manager-worker` / `gmail-refresh-token`):
+
+```bash
+security add-generic-password \
+  -a "task-manager-worker" \
+  -s "gmail-refresh-token" \
+  -w "<the refresh token>"
+```
+
+If you'd rather use a different account/service, set `GMAIL_KEYCHAIN_ACCOUNT`/
+`GMAIL_KEYCHAIN_SERVICE` in the plist's `EnvironmentVariables` to match whatever you stored it
+under.
+
+### 2. Build the worker and install the plist
+
+```bash
+pnpm --filter task-manager build   # produces apps/task-manager/dist/worker.js
+```
+
+Copy the template plist and fill in every `REPLACE_ME_*` placeholder (absolute path to `node`,
+absolute path to this repo checkout, `REDIS_URL`, `GMAIL_CLIENT_ID`, `GMAIL_CLIENT_SECRET`) —
+see the comments at the top of the plist for exactly what each one needs and where it comes from.
+Never commit a copy with real values filled in; the installed copy lives outside git:
+
+```bash
+cp apps/task-manager/launchd/com.ertrzyiks.task-manager-worker.plist \
+  ~/Library/LaunchAgents/com.ertrzyiks.task-manager-worker.plist
+# edit ~/Library/LaunchAgents/com.ertrzyiks.task-manager-worker.plist to replace the placeholders
+```
+
+Load it (modern `launchctl bootstrap`, or the older `load` if your macOS version prefers it):
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ertrzyiks.task-manager-worker.plist
+# or: launchctl load ~/Library/LaunchAgents/com.ertrzyiks.task-manager-worker.plist
+```
+
+### 3. Check it's running
+
+```bash
+launchctl list | grep com.ertrzyiks.task-manager-worker
+```
+
+A PID in the first column means it's running; a non-zero last-exit-status column means it exited
+and launchd is about to restart it (`KeepAlive`). Logs go to the `StandardOutPath`/
+`StandardErrorPath` files configured in the plist (`launchd/worker.log` /
+`launchd/worker-error.log` under your repo checkout by default).
+
+To stop/unload it:
+
+```bash
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.ertrzyiks.task-manager-worker.plist
+# or: launchctl unload ~/Library/LaunchAgents/com.ertrzyiks.task-manager-worker.plist
+```
+
+### Offline worker / missed jobs
+
+If the worker isn't running when a job is scheduled (laptop closed, LaunchAgent not loaded yet,
+etc.), no special handling is needed: jobs live in BullMQ's Redis-backed queue regardless of
+whether a consumer is currently connected, so the worker just picks up any waiting jobs the next
+time it starts or reconnects. `KeepAlive` handles the "worker crashed" case; Redis persistence
+handles the "worker wasn't running at all" case.
+
+### What's verifiable outside macOS
+
+This plist was developed and reviewed in a Linux sandbox, where `launchd`/`launchctl` don't exist,
+so it has never actually been loaded or run for real — same verification gap as `src/keychain.ts`'s
+real Keychain read (see the PR that introduced this file for what was and wasn't checked).

--- a/apps/task-manager/launchd/com.ertrzyiks.task-manager-worker.plist
+++ b/apps/task-manager/launchd/com.ertrzyiks.task-manager-worker.plist
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  LaunchAgent for the task-manager Mac worker (apps/task-manager/src/worker.ts, #249/#251).
+  Keeps the worker consuming the `extract-action-items` BullMQ queue whenever the user is
+  logged in, and restarts it automatically if it crashes or exits unexpectedly (KeepAlive,
+  subject to launchd's default crash-loop throttling).
+
+  This file is a TEMPLATE. Every REPLACE_ME_* placeholder below must be substituted with a
+  real, machine-specific value before installing — see the "macOS LaunchAgent" section of
+  apps/task-manager/README.md for the install steps and where each value comes from. Never
+  commit a copy of this file with real secrets filled in; the installed copy lives outside
+  git, under ~/Library/LaunchAgents/.
+
+    - REPLACE_ME_NODE_PATH: absolute path to a `node` binary (e.g. `which node`). launchd
+      does not read your shell's PATH/nvm setup, so a bare "node" will not resolve.
+    - REPLACE_ME_REPO_PATH: absolute path to this repo checkout, e.g.
+      /Users/you/code/ertrzyiks.me
+    - REPLACE_ME_REDIS_URL: same Redis instance the Jobs API server uses.
+    - REPLACE_ME_GMAIL_CLIENT_ID / REPLACE_ME_GMAIL_CLIENT_SECRET: the OAuth client for the
+      worker's gmail.readonly credential (see scripts/gmail-oauth/README.md, #247). The
+      refresh token itself is NOT an env var here — it's read from the macOS Keychain at
+      startup (src/keychain.ts); see the README for the `security add-generic-password`
+      command that stores it there.
+
+  Optional env vars (GMAIL_KEYCHAIN_ACCOUNT, GMAIL_KEYCHAIN_SERVICE, LM_STUDIO_BASE_URL) are
+  omitted here since worker.ts already falls back to sensible defaults (see src/worker.ts) —
+  add them under EnvironmentVariables below only if you need to override a default.
+
+  Runs the built `dist/worker.js` directly via `node` — NOT `pnpm run worker` (which runs
+  `tsx watch src/worker.ts`, the dev-only entrypoint) — matching how the Jobs API's `start`
+  script runs `dist/server.js` rather than a dev script. Run the task-manager package's
+  build script first (see apps/task-manager/README.md) so `dist/worker.js` exists at the
+  path referenced below.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.ertrzyiks.task-manager-worker</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>REPLACE_ME_NODE_PATH</string>
+    <string>REPLACE_ME_REPO_PATH/apps/task-manager/dist/worker.js</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>REPLACE_ME_REPO_PATH/apps/task-manager</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>REDIS_URL</key>
+    <string>REPLACE_ME_REDIS_URL</string>
+    <key>GMAIL_CLIENT_ID</key>
+    <string>REPLACE_ME_GMAIL_CLIENT_ID</string>
+    <key>GMAIL_CLIENT_SECRET</key>
+    <string>REPLACE_ME_GMAIL_CLIENT_SECRET</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>REPLACE_ME_REPO_PATH/apps/task-manager/launchd/worker.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>REPLACE_ME_REPO_PATH/apps/task-manager/launchd/worker-error.log</string>
+</dict>
+</plist>

--- a/scripts/gmail-oauth/README.md
+++ b/scripts/gmail-oauth/README.md
@@ -59,18 +59,19 @@ op item create --category=password --vault="Dokku apps" \
 ```
 (repeat for the other two items)
 
-**macOS Keychain** (read by the Mac worker at startup — implemented in #251, this just captures
-the secret now while you have it):
+**macOS Keychain** (read by the Mac worker at startup — see `apps/task-manager/src/keychain.ts`
+and the "macOS LaunchAgent" section of `apps/task-manager/README.md`, #251):
 
 ```bash
 security add-generic-password \
-  -a "$USER" \
-  -s "task-manager-gmail-refresh-token" \
+  -a "task-manager-worker" \
+  -s "gmail-refresh-token" \
   -w "<GMAIL_REFRESH_TOKEN value>"
 ```
 
-The service name above (`task-manager-gmail-refresh-token`) is provisional — #251 owns the actual
-Keychain read implementation and can rename it there if it picks a different convention.
+The account/service above (`task-manager-worker` / `gmail-refresh-token`) match `keychain.ts`'s
+defaults (`GMAIL_KEYCHAIN_ACCOUNT`/`GMAIL_KEYCHAIN_SERVICE`) — if you override those env vars for
+the worker, store the token under the same values instead.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Adds a template macOS LaunchAgent plist
  (`apps/task-manager/launchd/com.ertrzyiks.task-manager-worker.plist`) for the Mac worker
  built in #249: `RunAtLoad = true` (starts at login), `KeepAlive = true` (auto-restarts on
  crash, subject to launchd's default throttling), `ProgramArguments` runs the **built**
  `dist/worker.js` via `node` directly — not `pnpm run worker` (`tsx watch`, dev-only) —
  matching how `start` runs `dist/server.js`. `WorkingDirectory` and `EnvironmentVariables`
  (`REDIS_URL`, `GMAIL_CLIENT_ID`, `GMAIL_CLIENT_SECRET`) are `REPLACE_ME_*` placeholders
  with instructions in the plist's own comments — these are user-specific/secret and can't be
  hardcoded into a file checked into git. LM Studio's own lifecycle is intentionally not
  managed by this LaunchAgent, per the issue.
- Adds a "macOS LaunchAgent" section to `apps/task-manager/README.md` covering: storing the
  Gmail refresh token in the Keychain (`security add-generic-password` under the exact
  account/service `src/keychain.ts` actually reads by default — `task-manager-worker` /
  `gmail-refresh-token`), building and installing the plist
  (`cp` into `~/Library/LaunchAgents/`, `launchctl bootstrap`/`load`), checking it's running
  (`launchctl list | grep ...`), and why offline-worker job persistence needs no new code —
  BullMQ's Redis-backed queue already holds jobs regardless of consumer availability, so the
  worker just picks up waiting jobs whenever it next starts/reconnects.
- Corrects `scripts/gmail-oauth/README.md`'s Keychain snippet (from #247), which used a
  provisional account/service (`$USER` / `task-manager-gmail-refresh-token`) and explicitly
  deferred the real naming decision to this issue — updated it to the actual values
  `keychain.ts` reads (`task-manager-worker` / `gmail-refresh-token`) so the two docs don't
  disagree.
- No worker code changes: the Keychain-reading logic (`KeychainReader`, env vars
  `GMAIL_KEYCHAIN_ACCOUNT`/`GMAIL_KEYCHAIN_SERVICE`) was already built in #249/#266
  (`src/keychain.ts`, `src/worker.ts`) — this issue's remaining scope was the `.plist` and
  documentation, as called out in the issue.

## What could and couldn't be verified
This sandbox is Linux; `launchd`/`launchctl` don't exist here, so the LaunchAgent has never
actually been loaded or run for real. Same verification gap as #266's PR for the real Keychain
read.

**Verified for real:**
- The plist parses as well-formed XML (`xml.etree.ElementTree`) and contains exactly the keys
  Apple's LaunchAgent schema expects (`Label`, `ProgramArguments`, `WorkingDirectory`,
  `EnvironmentVariables`, `RunAtLoad`, `KeepAlive`, `StandardOutPath`, `StandardErrorPath`).
- `pnpm --filter task-manager build` succeeds and produces `dist/worker.js` — the exact path
  referenced by the plist's `ProgramArguments` (relative to `WorkingDirectory`/repo root).
- `tsc --noEmit` is clean.
- `pnpm --filter task-manager test` — 43/43 passing (no test changes needed; this PR only adds
  a plist and docs).
- `CI=true npx -y pnpm@11.20.0 install` reports "Already up to date" with no
  `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`/`ERR_PNPM_OUTDATED_LOCKFILE` — lockfile untouched (no
  dependency changes in this PR).

**Not verified, and can't be in this sandbox:**
- Actually loading the plist with `launchctl bootstrap`/`load` and confirming it starts the
  worker at login.
- `KeepAlive` actually restarting the worker after a real crash.
- A job scheduled while the worker (or the whole Mac) is offline actually being picked up once
  the LaunchAgent starts it — this relies on BullMQ/Redis behavior already verified in #266's
  PR (a live second-process smoke test against real Redis), not on anything new in this PR.
- The real Keychain read itself (`security find-generic-password`) — same gap as #266.

## Test plan
- [x] `pnpm --filter task-manager test` — 43/43 passing
- [x] `tsc --noEmit` passes
- [x] `pnpm --filter task-manager build` succeeds; `dist/worker.js` exists at the path the
      plist references
- [x] Plist validated as well-formed XML with the expected LaunchAgent keys
      (`xml.etree.ElementTree`, since `plutil` isn't available on Linux)
- [x] `CI=true npx -y pnpm@11.20.0 install` — lockfile clean, no warnings/errors
- [ ] Real `launchctl bootstrap`/`load` — can't verify outside macOS
- [ ] Real crash-and-restart via `KeepAlive` — can't verify outside macOS
- [ ] Real offline-job pickup end-to-end via the LaunchAgent — can't verify outside macOS

Closes #251
