### PR TITLE
Add path-filtered CI release workflows for task-manager and personal-assistant

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,32 @@ on:
     branches: [master]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      home: ${{ steps.filter.outputs.home }}
+      blog: ${{ steps.filter.outputs.blog }}
+      task_manager: ${{ steps.filter.outputs.task_manager }}
+      personal_assistant: ${{ steps.filter.outputs.personal_assistant }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            shared: &shared
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.nvmrc'
+            home: [*shared, 'apps/home/**']
+            blog: [*shared, 'apps/blog/**']
+            task_manager: [*shared, 'apps/task-manager/**']
+            personal_assistant: [*shared, 'apps/personal-assistant/**']
+
   release_home:
+    needs: changes
+    if: needs.changes.outputs.home == 'true'
     uses: ./.github/workflows/release_homepage.yml
     with:
       ref: ${{ github.ref }}
@@ -13,8 +38,27 @@ jobs:
       DOKKU_DEPLOY_KEY: ${{ secrets.DOKKU_DEPLOY_KEY }}
 
   release_blog:
-    needs: release_home
+    needs: changes
+    if: needs.changes.outputs.blog == 'true'
     uses: ./.github/workflows/release_blog.yml
+    with:
+      ref: ${{ github.ref }}
+    secrets:
+      DOKKU_DEPLOY_KEY: ${{ secrets.DOKKU_DEPLOY_KEY }}
+
+  release_task_manager:
+    needs: changes
+    if: needs.changes.outputs.task_manager == 'true'
+    uses: ./.github/workflows/release_task_manager.yml
+    with:
+      ref: ${{ github.ref }}
+    secrets:
+      DOKKU_DEPLOY_KEY: ${{ secrets.DOKKU_DEPLOY_KEY }}
+
+  release_personal_assistant:
+    needs: changes
+    if: needs.changes.outputs.personal_assistant == 'true'
+    uses: ./.github/workflows/release_personal_assistant.yml
     with:
       ref: ${{ github.ref }}
     secrets:

--- a/.github/workflows/release_personal_assistant.yml
+++ b/.github/workflows/release_personal_assistant.yml
@@ -1,0 +1,104 @@
+name: Release Personal Assistant
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Reference to deploy"
+        type: string
+        default: "master"
+    secrets:
+      DOKKU_DEPLOY_KEY:
+        required: true
+
+concurrency: personal-assistant-production
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref || 'master' }}
+
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - uses: pnpm/action-setup@v6.0.10
+        with:
+          version: 11.20.0
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v6.1.0
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Test
+        run: pnpm test
+        working-directory: ./apps/personal-assistant
+
+      - name: Build
+        run: pnpm build
+        working-directory: ./apps/personal-assistant
+
+      # See release_task_manager.yml for why this synthesizes a deploy-only package.json/
+      # lockfile instead of reusing the workspace's pnpm-lock.yaml.
+      #
+      # Unlike task-manager's Fastify server, personal-assistant's entrypoint
+      # (src/server.ts) never binds an HTTP port — it's a poller with no inbound traffic
+      # (see apps/personal-assistant/README.md). Declaring it as a `web:` Procfile process
+      # would make Dokku route personal-assistant.ertrzyiks.me to it and run its default
+      # HTTP healthcheck against a port that's never listened on, which would fail the
+      # zero-downtime deploy check. So this ships as a `worker:` process type instead, which
+      # Dokku does not HTTP-healthcheck or auto-scale up on deploy — see the PR description
+      # for the one-time manual `dokku ps:scale personal-assistant worker=1` step this implies.
+      - name: Prepare deploy package
+        working-directory: ./apps/personal-assistant
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            const deployPkg = {
+              name: pkg.name,
+              version: pkg.version,
+              private: true,
+              type: pkg.type,
+              scripts: { start: 'node server.js' },
+              dependencies: pkg.dependencies,
+            };
+            fs.writeFileSync('dist/package.json', JSON.stringify(deployPkg, null, 2) + '\n');
+          "
+          printf 'worker: node server.js\n' > dist/Procfile
+          cd dist && npm install --package-lock-only
+
+      - uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.DOKKU_DEPLOY_KEY }}
+
+      - run: echo '167.71.190.115 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEYg+BGxM8IdEoQ8fx7aDoclC0eNXSpI6l/QkLRMF/cvjJcSCk4kz/4LEkSU8eXFawp8IX/yNOyV11sJZtCVBCs=' >> ~/.ssh/known_hosts
+
+      - working-directory: ./apps/personal-assistant/dist
+        run: |
+          git init
+          git config --global user.email "deploy-bot@ertrzyiks.me"
+          git config --global user.name "Deploy Bot"
+          git remote add dokku dokku@167.71.190.115:personal-assistant
+          git add .
+          git commit -m 'Update'
+          git push dokku HEAD:master --force

--- a/.github/workflows/release_task_manager.yml
+++ b/.github/workflows/release_task_manager.yml
@@ -1,0 +1,102 @@
+name: Release Task Manager
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Reference to deploy"
+        type: string
+        default: "master"
+    secrets:
+      DOKKU_DEPLOY_KEY:
+        required: true
+
+concurrency: task-manager-production
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref || 'master' }}
+
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - uses: pnpm/action-setup@v6.0.10
+        with:
+          version: 11.20.0
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v6.1.0
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Test
+        run: pnpm test
+        working-directory: ./apps/task-manager
+
+      - name: Build
+        run: pnpm build
+        working-directory: ./apps/task-manager
+
+      # Dokku's Node/Herokuish buildpack (not the static buildpack `release_blog.yml`/
+      # `release_homepage.yml` use) needs a `package.json` + lockfile alongside the app so it
+      # can `npm install` production dependencies server-side, and a `Procfile` telling it what
+      # process to run. `apps/task-manager` is a pnpm workspace member with no lockfile of its
+      # own, so we synthesize a minimal, deploy-only `package.json` (name/version/type/
+      # dependencies only — no devDependencies, no workspace-relative anything) and a plain npm
+      # lockfile for it, then push the pre-built `dist/` output alongside them. TypeScript
+      # compilation itself already happened above via `pnpm build`, so the buildpack's own
+      # install step stays a plain `npm install` with no build step of its own to run.
+      - name: Prepare deploy package
+        working-directory: ./apps/task-manager
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            const deployPkg = {
+              name: pkg.name,
+              version: pkg.version,
+              private: true,
+              type: pkg.type,
+              scripts: { start: 'node server.js' },
+              dependencies: pkg.dependencies,
+            };
+            fs.writeFileSync('dist/package.json', JSON.stringify(deployPkg, null, 2) + '\n');
+          "
+          printf 'web: node server.js\n' > dist/Procfile
+          cd dist && npm install --package-lock-only
+
+      - uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.DOKKU_DEPLOY_KEY }}
+
+      - run: echo '167.71.190.115 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEYg+BGxM8IdEoQ8fx7aDoclC0eNXSpI6l/QkLRMF/cvjJcSCk4kz/4LEkSU8eXFawp8IX/yNOyV11sJZtCVBCs=' >> ~/.ssh/known_hosts
+
+      - working-directory: ./apps/task-manager/dist
+        run: |
+          git init
+          git config --global user.email "deploy-bot@ertrzyiks.me"
+          git config --global user.name "Deploy Bot"
+          git remote add dokku dokku@167.71.190.115:task-manager
+          git add .
+          git commit -m 'Update'
+          git push dokku HEAD:master --force


### PR DESCRIPTION
## Summary
Final PR in this stack. Adds the two new release workflows and the change-detection mechanism so CI only redeploys the app(s) that actually changed, per the decision in #246.

- **`release_task_manager.yml`** / **`release_personal_assistant.yml`** — reusable `workflow_call` workflows deploying `apps/task-manager`/`apps/personal-assistant` to their Dokku apps (provisioned in #252).
- **`main.yml`**: added a `changes` job (`dorny/paths-filter@v3`) and gated all four release jobs behind `needs: changes` + a per-app `if:`. Dropped the arbitrary `release_blog: needs: release_home` ordering — no functional dependency between unrelated Dokku apps, all four releases are now fully parallel.

### Deploy-shape decision
`release_blog.yml`/`release_homepage.yml` push a **static** `dist/` to Dokku's static buildpack. `task-manager`/`personal-assistant` are real Node servers, so this instead: builds in CI (`pnpm build` → `dist/*.js`), synthesizes a deploy-only `package.json` (name/version/type/dependencies only, `scripts.start: "node server.js"`) plus a freshly generated npm lockfile and a `Procfile`, writes them into `dist/`, then git-inits and pushes that folder — same push-the-build-output shape as blog/home, adapted with a `Procfile` + lockfile so Dokku's Herokuish Node buildpack can `npm install` production deps server-side.

Rejected alternatives: shipping full source and letting the buildpack run `pnpm install`+`tsc` itself (uncertain Herokuish pnpm-workspace support); shipping pre-built `node_modules` via `pnpm deploy --prod` (verified working, but ~250MB push, dominated by `googleapis`).

**Important non-obvious detail**: `apps/personal-assistant`'s `src/server.ts` never binds an HTTP port — it's a Gmail poller, not a web server (see its README). Its `Procfile` declares `worker:`, not `web:`, so Dokku doesn't zero-downtime-healthcheck an HTTP port nothing listens on. **After the first real deploy, someone needs to run `dokku ps:scale personal-assistant worker=1` on the Dokku host** — a manual, one-time step outside CI's reach.

Closes #253.

## Test plan
- [x] All 3 workflow YAMLs parse as valid YAML
- [x] `pnpm --filter task-manager build` / `--filter personal-assistant build` both succeed, producing `dist/*.js`
- [x] Full end-to-end simulation of the deploy artifact for both apps: trimmed `package.json` → `npm install --package-lock-only` → `npm ci --omit=dev` → `node server.js` next to the built `dist/` — each starts and fails only on the expected missing env var/mount (`REDIS_URL`, `/app/data`), i.e. gets fully through module loading
- [x] `CI=true npx -y pnpm@11.20.0 --filter task-manager test` — 43/43 passing
- [x] `CI=true npx -y pnpm@11.20.0 --filter personal-assistant test` — 39/39 passing
- [x] `CI=true npx -y pnpm@11.20.0 install` — "Already up to date", no warnings (no `package.json` changes in this PR)
- [ ] Not verifiable in this sandbox: an actual Dokku deploy, Herokuish buildpack behavior, `ps:scale`, DNS/routing
