### PR TITLE
Fix task-manager release build: migrate bullmq to v6, add PR CI coverage

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -93,3 +93,87 @@ jobs:
       - name: Build
         run: pnpm build
         working-directory: ./apps/home
+
+  build_task_manager:
+    name: Build Task Manager
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - uses: pnpm/action-setup@v6.0.10
+        with:
+          version: 11.20.0
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v6.1.0
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Test
+        run: pnpm test
+        working-directory: ./apps/task-manager
+
+      - name: Build
+        run: pnpm build
+        working-directory: ./apps/task-manager
+
+  build_personal_assistant:
+    name: Build Personal Assistant
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - uses: pnpm/action-setup@v6.0.10
+        with:
+          version: 11.20.0
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v6.1.0
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Test
+        run: pnpm test
+        working-directory: ./apps/personal-assistant
+
+      - name: Build
+        run: pnpm build
+        working-directory: ./apps/personal-assistant

--- a/apps/task-manager/package.json
+++ b/apps/task-manager/package.json
@@ -13,15 +13,15 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "bullmq": "5.81.3",
+    "bullmq": "6.0.8",
     "fastify": "5.11.2",
-    "google-auth-library": "10.9.1",
+    "google-auth-library": "10.5.0",
     "googleapis": "173.0.0",
     "ioredis": "6.0.0"
   },
   "devDependencies": {
-    "@bull-board/api": "8.4.0",
-    "@bull-board/fastify": "8.4.0",
+    "@bull-board/api": "8.6.0",
+    "@bull-board/fastify": "8.6.0",
     "@types/node": "24.13.3",
     "dotenv": "17.4.2",
     "tsx": "4.23.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,14 +113,14 @@ importers:
   apps/task-manager:
     dependencies:
       bullmq:
-        specifier: 5.81.3
-        version: 5.81.3
+        specifier: 6.0.8
+        version: 6.0.8(ioredis@6.0.0)
       fastify:
         specifier: 5.11.2
         version: 5.11.2
       google-auth-library:
-        specifier: 10.9.1
-        version: 10.9.1
+        specifier: 10.5.0
+        version: 10.5.0
       googleapis:
         specifier: 173.0.0
         version: 173.0.0
@@ -129,11 +129,11 @@ importers:
         version: 6.0.0
     devDependencies:
       '@bull-board/api':
-        specifier: 8.4.0
-        version: 8.4.0(@bull-board/ui@8.4.0(bullmq@5.81.3))(bullmq@5.81.3)
+        specifier: 8.6.0
+        version: 8.6.0(@bull-board/ui@8.6.0(bullmq@6.0.8(ioredis@6.0.0)))(bullmq@6.0.8(ioredis@6.0.0))
       '@bull-board/fastify':
-        specifier: 8.4.0
-        version: 8.4.0(bullmq@5.81.3)
+        specifier: 8.6.0
+        version: 8.6.0(bullmq@6.0.8(ioredis@6.0.0))
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
@@ -340,23 +340,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@bull-board/api@8.4.0':
-    resolution: {integrity: sha512-RUAqQ4Y6G2k4eIzKJgYHs8qx2nCRiOfCNUEwfnz6SCrHwRZ5TKJ9ZlYBjIuGY9kA5s1et+jm0xwfiVJWNwflKA==}
+  '@bull-board/api@8.6.0':
+    resolution: {integrity: sha512-tJLkYszUJhvDzTexLT+6/OEUYCWrR5QBKXk+SNlNsxHw8WClSRFEirXMrKwrei3LlMVxPV5lvbBOC7LNNymibQ==}
     peerDependencies:
-      '@bull-board/ui': 8.4.0
+      '@bull-board/ui': 8.6.0
       bull: ^4.16.5
-      bullmq: ^5.79.2
+      bullmq: ^5.79.2 || ^6.0.0
     peerDependenciesMeta:
       bull:
         optional: true
       bullmq:
         optional: true
 
-  '@bull-board/fastify@8.4.0':
-    resolution: {integrity: sha512-1jKJU4zBRuh9M5vv52McKOIQajJEJT5MS0ppTrFfrZwFm2xPY1avAN8Jw3TBfbtWw0OKu9JK/qaevqYiu+IQFA==}
+  '@bull-board/fastify@8.6.0':
+    resolution: {integrity: sha512-Th5ExBU8pe0MfkhSRSDAZ3Y/eMxdSeFnAoUQ98qJNjYtykaEVkTL0VyTozKRAHb1Dggg3K31VS1j1a7JwlTNfA==}
 
-  '@bull-board/ui@8.4.0':
-    resolution: {integrity: sha512-N35K90lCAz2URwBtCXS1O/bOyU4/d7qeEZ7cx/qWWu0rn3NakwLC/oHNuU6L8R1qKBy2wVl8i5AxHdp2Mg3KNA==}
+  '@bull-board/ui@8.6.0':
+    resolution: {integrity: sha512-Qb/HYNU2JhRYKoyeJhXgeu1ZL4VK5RANmLC/cpzbtZPz5b9b260d0J0Af0L0zGdP6ORYg2XpPQKwrIy7n96AwQ==}
 
   '@capsizecss/unpack@4.0.1':
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
@@ -1405,12 +1405,21 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
-  bullmq@5.81.3:
-    resolution: {integrity: sha512-Q7uEH2G92rVjX3Yl2qw3+6VEO15uxehC6DfeTHQBQTehddcRDSDuquD9zuvDjxiCffXsPUaBwrRlvlbVcgKs7g==}
-    engines: {node: '>=12.22.0'}
+  bullmq@6.0.8:
+    resolution: {integrity: sha512-GsO8S9e5SaQbB4S3kRKNveaYVNxMQlSup7cgk0rRJyr5nwZ4ArftcqPmzJSCqZvJZQqONuwOzs2VKFySvxtbog==}
+    engines: {node: '>=14.17.0'}
     peerDependencies:
+      bullmq-otel: '>=2.0.0'
+      ioredis: '>=5.0.0'
+      pg: '>=8.0.0'
       redis: '>=5.0.0'
     peerDependenciesMeta:
+      bullmq-otel:
+        optional: true
+      ioredis:
+        optional: true
+      pg:
+        optional: true
       redis:
         optional: true
 
@@ -1504,10 +1513,9 @@ packages:
     resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
     engines: {node: '>=22'}
 
-  cron-parser@4.9.0:
-    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
-    engines: {node: '>=12.0.0'}
-    deprecated: v4 is no longer maintained, upgrade to v5
+  cron-parser@5.7.0:
+    resolution: {integrity: sha512-iSpDHpwwW/GhIg4JVODYlWUEpMNSimaHvqOhHpOz1W+Y97z1lL1nf+dpcF17cNwFRpTtKN9devgi1fxflp3Phw==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1823,10 +1831,6 @@ packages:
     resolution: {integrity: sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==}
     engines: {node: '>=18'}
 
-  gcp-metadata@8.1.2:
-    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
-    engines: {node: '>=18'}
-
   gcp-metadata@8.1.4:
     resolution: {integrity: sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==}
     engines: {node: '>=18'}
@@ -1868,10 +1872,6 @@ packages:
 
   google-auth-library@10.5.0:
     resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
-    engines: {node: '>=18'}
-
-  google-auth-library@10.9.1:
-    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
     engines: {node: '>=18'}
 
   google-logging-utils@1.1.3:
@@ -3548,17 +3548,17 @@ snapshots:
   '@bruits/satteri-win32-x64-msvc@0.9.5':
     optional: true
 
-  '@bull-board/api@8.4.0(@bull-board/ui@8.4.0(bullmq@5.81.3))(bullmq@5.81.3)':
+  '@bull-board/api@8.6.0(@bull-board/ui@8.6.0(bullmq@6.0.8(ioredis@6.0.0)))(bullmq@6.0.8(ioredis@6.0.0))':
     dependencies:
-      '@bull-board/ui': 8.4.0(bullmq@5.81.3)
+      '@bull-board/ui': 8.6.0(bullmq@6.0.8(ioredis@6.0.0))
       redis-info: 3.1.0
     optionalDependencies:
-      bullmq: 5.81.3
+      bullmq: 6.0.8(ioredis@6.0.0)
 
-  '@bull-board/fastify@8.4.0(bullmq@5.81.3)':
+  '@bull-board/fastify@8.6.0(bullmq@6.0.8(ioredis@6.0.0))':
     dependencies:
-      '@bull-board/api': 8.4.0(@bull-board/ui@8.4.0(bullmq@5.81.3))(bullmq@5.81.3)
-      '@bull-board/ui': 8.4.0(bullmq@5.81.3)
+      '@bull-board/api': 8.6.0(@bull-board/ui@8.6.0(bullmq@6.0.8(ioredis@6.0.0)))(bullmq@6.0.8(ioredis@6.0.0))
+      '@bull-board/ui': 8.6.0(bullmq@6.0.8(ioredis@6.0.0))
       '@fastify/static': 10.1.2
       '@fastify/view': 12.0.0
       ejs: 6.0.1
@@ -3566,9 +3566,9 @@ snapshots:
       - bull
       - bullmq
 
-  '@bull-board/ui@8.4.0(bullmq@5.81.3)':
+  '@bull-board/ui@8.6.0(bullmq@6.0.8(ioredis@6.0.0))':
     dependencies:
-      '@bull-board/api': 8.4.0(@bull-board/ui@8.4.0(bullmq@5.81.3))(bullmq@5.81.3)
+      '@bull-board/api': 8.6.0(@bull-board/ui@8.6.0(bullmq@6.0.8(ioredis@6.0.0)))(bullmq@6.0.8(ioredis@6.0.0))
     transitivePeerDependencies:
       - bull
       - bullmq
@@ -3884,7 +3884,8 @@ snapshots:
   '@img/sharp-win32-x64@0.35.3':
     optional: true
 
-  '@ioredis/commands@1.10.0': {}
+  '@ioredis/commands@1.10.0':
+    optional: true
 
   '@ioredis/commands@2.0.0': {}
 
@@ -4514,16 +4515,15 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
-  bullmq@5.81.3:
+  bullmq@6.0.8(ioredis@6.0.0):
     dependencies:
-      cron-parser: 4.9.0
-      ioredis: 5.11.1
+      cron-parser: 5.7.0
       msgpackr: 2.0.5
       node-abort-controller: 3.1.1
       semver: 7.8.5
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
+    optionalDependencies:
+      ioredis: 6.0.0
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -4591,7 +4591,7 @@ snapshots:
 
   cookie@2.0.1: {}
 
-  cron-parser@4.9.0:
+  cron-parser@5.7.0:
     dependencies:
       luxon: 3.7.2
 
@@ -4946,14 +4946,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gcp-metadata@8.1.2:
-    dependencies:
-      gaxios: 7.3.0
-      google-logging-utils: 1.2.0
-      json-bigint: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   gcp-metadata@8.1.4:
     dependencies:
       gaxios: 7.1.3
@@ -5021,17 +5013,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  google-auth-library@10.9.1:
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.3.0
-      gcp-metadata: 8.1.2
-      google-logging-utils: 1.1.3
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   google-logging-utils@1.1.3: {}
 
   google-logging-utils@1.2.0: {}
@@ -5049,7 +5030,7 @@ snapshots:
 
   googleapis@173.0.0:
     dependencies:
-      google-auth-library: 10.9.1
+      google-auth-library: 10.5.0
       googleapis-common: 8.0.3
     transitivePeerDependencies:
       - supports-color
@@ -5247,6 +5228,7 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   ioredis@6.0.0:
     dependencies:
@@ -6124,6 +6106,7 @@ snapshots:
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
+    optional: true
 
   regex-recursion@6.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,10 @@ allowBuilds:
   sharp: true
 minimumReleaseAgeExclude:
   - ipaddr.js@2.5.0
+  - '@bull-board/api@8.6.0'
+  - '@bull-board/fastify@8.6.0'
+  - '@bull-board/ui@8.6.0'
+  - bullmq@6.0.8
 overrides:
   ipaddr.js: 2.5.0
   tsx: 4.23.1


### PR DESCRIPTION
Two independent Renovate PRs merged back-to-back (#272 ioredis 5→6, #275 google-auth-library 10.5.0→10.9.1) bumped apps/task-manager's direct dependencies past what its own transitive deps hard-pin:

- bullmq@5.81.3 pins "ioredis": "5.11.1" exactly (not a peer/range)
- googleapis-common@8.0.3 (pulled in by googleapis) pins "google-auth-library": "10.5.0" exactly, and still does as of the latest googleapis@174.0.1 today

pnpm's isolated node_modules then installed two copies of each package. TypeScript treats classes with private members from two different module instances as nominally distinct, so passing task-manager's own Redis/OAuth2Client instances into bullmq/googleapis APIs no longer type-checked (queue.ts, worker.ts, gmail.ts), breaking `tsc` in the post-merge release_task_manager workflow (run 31020292535).

Resolution, per dependency:

- ioredis: bullmq@6.0.8 turns ioredis into an open peer dependency (">=5.0.0"), so it can actually go forward. Bumped bullmq 5.81.3→6.0.8 and @bull-board/api + @bull-board/fastify 8.4.0→8.6.0 (the first release where @bull-board/api's peer range accepts bullmq ^6.0.0). Verified with real Queue/Worker/Bull-Board smoke tests against a live Redis (bullmq's own release notes call this a substantial internal rework — "pluggable queue backends" — so type checks and mocked unit tests alone weren't enough signal here).
- google-auth-library: no forward path exists — googleapis-common hard-pins it exactly, today and in every version checked. Pinned task-manager's direct dependency back to 10.5.0 to match.

`pnpm dedupe` after both changes collapses each package back to a single resolved copy, matching how they resolved before either Renovate PR landed.

Why this reached master: `pr.yml` (the required PR CI check) only builds apps/blog and apps/home — it never touched task-manager or personal-assistant. Both Renovate PRs showed all-green checks and were merged in good faith, and the break was only caught after landing on master when the path-filtered release workflow ran `tsc`/tests for real. Adds build_task_manager and build_personal_assistant jobs to pr.yml, mirroring the existing test+build steps from their release workflows, so future PRs touching either app (Renovate or otherwise) get real signal before merge instead of after.