### PR TITLE
Migrate task-manager and personal-assistant to Dockerfile-based dokku deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Docker build context is the repo root (needed so the per-app Dockerfiles can `pnpm install`
+# against the shared workspace lockfile). Keep this list broad — anything not copied here still
+# works fine, it just makes the build context upload slower.
+.git
+.github
+.claude
+node_modules
+**/node_modules
+apps/*/dist
+apps/*/.env
+apps/*/data
+apps/*/coverage
+terraform
+scripts
+*.md
+.DS_Store

--- a/.github/workflows/release_personal_assistant.yml
+++ b/.github/workflows/release_personal_assistant.yml
@@ -14,9 +14,16 @@ on:
 
 concurrency: personal-assistant-production
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/personal-assistant
+
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v7.0.1
@@ -53,52 +60,48 @@ jobs:
         run: pnpm test
         working-directory: ./apps/personal-assistant
 
-      - name: Build
-        run: pnpm build
-        working-directory: ./apps/personal-assistant
-
-      # See release_task_manager.yml for why this synthesizes a deploy-only package.json/
-      # lockfile instead of reusing the workspace's pnpm-lock.yaml.
-      #
-      # Unlike task-manager's Fastify server, personal-assistant's entrypoint
-      # (src/server.ts) never binds an HTTP port — it's a poller with no inbound traffic
-      # (see apps/personal-assistant/README.md). Declaring it as a `web:` Procfile process
-      # would make Dokku route personal-assistant.ertrzyiks.me to it and run its default
-      # HTTP healthcheck against a port that's never listened on, which would fail the
-      # zero-downtime deploy check. So this ships as a `worker:` process type instead, which
-      # Dokku does not HTTP-healthcheck or auto-scale up on deploy — see the PR description
-      # for the one-time manual `dokku ps:scale personal-assistant worker=1` step this implies.
-      - name: Prepare deploy package
-        working-directory: ./apps/personal-assistant
-        run: |
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            const deployPkg = {
-              name: pkg.name,
-              version: pkg.version,
-              private: true,
-              type: pkg.type,
-              scripts: { start: 'node server.js' },
-              dependencies: pkg.dependencies,
-            };
-            fs.writeFileSync('dist/package.json', JSON.stringify(deployPkg, null, 2) + '\n');
-          "
-          printf 'worker: node server.js\n' > dist/Procfile
-          cd dist && npm install --package-lock-only
-
-      - uses: webfactory/ssh-agent@v0.10.0
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4.6.0
         with:
-          ssh-private-key: ${{ secrets.DOKKU_DEPLOY_KEY }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: echo '167.71.190.115 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEYg+BGxM8IdEoQ8fx7aDoclC0eNXSpI6l/QkLRMF/cvjJcSCk4kz/4LEkSU8eXFawp8IX/yNOyV11sJZtCVBCs=' >> ~/.ssh/known_hosts
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
 
-      - working-directory: ./apps/personal-assistant/dist
-        run: |
-          git init
-          git config --global user.email "deploy-bot@ertrzyiks.me"
-          git config --global user.name "Deploy Bot"
-          git remote add dokku dokku@167.71.190.115:personal-assistant
-          git add .
-          git commit -m 'Update'
-          git push dokku HEAD:master --force
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+
+      # Build context is the repo root, not ./apps/personal-assistant — the Dockerfile needs the
+      # shared pnpm workspace lockfile to install this app's dependencies. See
+      # apps/personal-assistant/Dockerfile.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          push: true
+          file: ./apps/personal-assistant/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=personal-assistant
+          cache-to: type=gha,mode=max,scope=personal-assistant
+
+      # Dokku reads a `Procfile` from the deployed image's WORKDIR to still start this as a
+      # `worker` process, not `web` (see apps/personal-assistant/Procfile and its README for why)
+      # — no herokuish/buildpack involved, just `git:from-image` pulling the digest built above.
+      # This app was already scaled to worker=1/web=0 from the previous buildpack deploy; that
+      # scale setting is per-app state on the Dokku host and isn't touched by switching builders,
+      # so no manual `dokku ps:scale` step is needed for this migration.
+      - name: Push to dokku
+        uses: dokku/github-action@v1.10.0
+        with:
+          git_remote_url: "ssh://dokku@167.71.190.115/personal-assistant"
+          ssh_private_key: ${{ secrets.DOKKU_DEPLOY_KEY }}
+          deploy_docker_image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}

--- a/.github/workflows/release_task_manager.yml
+++ b/.github/workflows/release_task_manager.yml
@@ -14,9 +14,16 @@ on:
 
 concurrency: task-manager-production
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/task-manager
+
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v7.0.1
@@ -53,50 +60,44 @@ jobs:
         run: pnpm test
         working-directory: ./apps/task-manager
 
-      - name: Build
-        run: pnpm build
-        working-directory: ./apps/task-manager
-
-      # Dokku's Node/Herokuish buildpack (not the static buildpack `release_blog.yml`/
-      # `release_homepage.yml` use) needs a `package.json` + lockfile alongside the app so it
-      # can `npm install` production dependencies server-side, and a `Procfile` telling it what
-      # process to run. `apps/task-manager` is a pnpm workspace member with no lockfile of its
-      # own, so we synthesize a minimal, deploy-only `package.json` (name/version/type/
-      # dependencies only — no devDependencies, no workspace-relative anything) and a plain npm
-      # lockfile for it, then push the pre-built `dist/` output alongside them. TypeScript
-      # compilation itself already happened above via `pnpm build`, so the buildpack's own
-      # install step stays a plain `npm install` with no build step of its own to run.
-      - name: Prepare deploy package
-        working-directory: ./apps/task-manager
-        run: |
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            const deployPkg = {
-              name: pkg.name,
-              version: pkg.version,
-              private: true,
-              type: pkg.type,
-              scripts: { start: 'node server.js' },
-              dependencies: pkg.dependencies,
-            };
-            fs.writeFileSync('dist/package.json', JSON.stringify(deployPkg, null, 2) + '\n');
-          "
-          printf 'web: node server.js\n' > dist/Procfile
-          cd dist && npm install --package-lock-only
-
-      - uses: webfactory/ssh-agent@v0.10.0
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4.6.0
         with:
-          ssh-private-key: ${{ secrets.DOKKU_DEPLOY_KEY }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: echo '167.71.190.115 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEYg+BGxM8IdEoQ8fx7aDoclC0eNXSpI6l/QkLRMF/cvjJcSCk4kz/4LEkSU8eXFawp8IX/yNOyV11sJZtCVBCs=' >> ~/.ssh/known_hosts
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
 
-      - working-directory: ./apps/task-manager/dist
-        run: |
-          git init
-          git config --global user.email "deploy-bot@ertrzyiks.me"
-          git config --global user.name "Deploy Bot"
-          git remote add dokku dokku@167.71.190.115:task-manager
-          git add .
-          git commit -m 'Update'
-          git push dokku HEAD:master --force
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+
+      # Build context is the repo root, not ./apps/task-manager — the Dockerfile needs the shared
+      # pnpm workspace lockfile to install this app's dependencies. See apps/task-manager/Dockerfile.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          push: true
+          file: ./apps/task-manager/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=task-manager
+          cache-to: type=gha,mode=max,scope=task-manager
+
+      # Dokku reads a `Procfile` from the deployed image's WORKDIR to still start this as a `web`
+      # process (see apps/task-manager/Procfile) — no herokuish/buildpack involved, just
+      # `git:from-image` pulling the digest built above.
+      - name: Push to dokku
+        uses: dokku/github-action@v1.10.0
+        with:
+          git_remote_url: "ssh://dokku@167.71.190.115/task-manager"
+          ssh_private_key: ${{ secrets.DOKKU_DEPLOY_KEY }}
+          deploy_docker_image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}

--- a/apps/personal-assistant/Dockerfile
+++ b/apps/personal-assistant/Dockerfile
@@ -1,0 +1,51 @@
+# Build context is the repo root (see release_personal_assistant.yml) — this app is a pnpm
+# workspace member and needs the shared lockfile/workspace manifest to install correctly.
+#
+# `server.ts` (built here as `dist/server.js`) is a poller with no inbound HTTP traffic — see
+# Procfile below and README.md for why this ships as a `worker:` process rather than `web:`.
+
+FROM node:24.19.0-slim AS build
+WORKDIR /repo
+
+RUN npm install -g pnpm@11.20.0
+
+# Only the files pnpm needs to resolve the workspace against the lockfile — not every app's
+# package.json, just this one (pnpm silently narrows its workspace scope to whatever package.json
+# files are actually present) plus `patches/`, since pnpm-workspace.yaml's `patchedDependencies`
+# is validated against the lockfile on every install regardless of which app is being built.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches
+COPY apps/personal-assistant/package.json apps/personal-assistant/package.json
+RUN pnpm install --frozen-lockfile
+
+COPY apps/personal-assistant apps/personal-assistant
+RUN pnpm --filter personal-assistant build
+
+# Dokku's Dockerfile builder reads a `Procfile` from the image's WORKDIR (see Procfile below), the
+# same mechanism the old herokuish buildpack deploy relied on — so, like that deploy, this
+# synthesizes a deploy-only `package.json` (name/version/type/dependencies only — no
+# devDependencies, no workspace-relative anything) and lets plain `npm install` resolve
+# production-only dependencies directly into `dist/`, rather than shipping the whole pnpm
+# workspace's hoisted node_modules into the image.
+RUN node -e " \
+    const fs = require('fs'); \
+    const pkg = JSON.parse(fs.readFileSync('apps/personal-assistant/package.json', 'utf8')); \
+    const deployPkg = { \
+      name: pkg.name, \
+      version: pkg.version, \
+      private: true, \
+      type: pkg.type, \
+      dependencies: pkg.dependencies, \
+    }; \
+    fs.writeFileSync('apps/personal-assistant/dist/package.json', JSON.stringify(deployPkg, null, 2) + '\n'); \
+  "
+WORKDIR /repo/apps/personal-assistant/dist
+RUN npm install --omit=dev
+
+FROM node:24.19.0-slim AS runtime
+WORKDIR /app
+COPY --from=build /repo/apps/personal-assistant/dist ./
+COPY apps/personal-assistant/Procfile ./Procfile
+
+ENV NODE_ENV=production
+CMD ["node", "server.js"]

--- a/apps/personal-assistant/Procfile
+++ b/apps/personal-assistant/Procfile
@@ -1,0 +1,1 @@
+worker: node server.js

--- a/apps/task-manager/Dockerfile
+++ b/apps/task-manager/Dockerfile
@@ -1,0 +1,56 @@
+# Build context is the repo root (see release_task_manager.yml) — this app is a pnpm workspace
+# member and needs the shared lockfile/workspace manifest to install correctly.
+#
+# `apps/task-manager` also contains `src/worker.ts`, the Mac-only worker that reads email content
+# via the local Keychain/LM Studio (see README.md). It never runs on Dokku — only the Jobs API
+# server (`server.ts`) is deployed here, so this image builds and ships `dist/server.js` only.
+
+FROM node:24.19.0-slim AS build
+WORKDIR /repo
+
+RUN npm install -g pnpm@11.20.0
+
+# Only the files pnpm needs to resolve the workspace against the lockfile — not every app's
+# package.json, just this one (pnpm silently narrows its workspace scope to whatever package.json
+# files are actually present) plus `patches/`, since pnpm-workspace.yaml's `patchedDependencies`
+# is validated against the lockfile on every install regardless of which app is being built.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches
+COPY apps/task-manager/package.json apps/task-manager/package.json
+RUN pnpm install --frozen-lockfile
+
+COPY apps/task-manager apps/task-manager
+RUN pnpm --filter task-manager build
+
+# Dokku's Dockerfile builder reads a `Procfile` from the image's WORKDIR (see Procfile below), the
+# same mechanism the old herokuish buildpack deploy relied on — so, like that deploy, this
+# synthesizes a deploy-only `package.json` (name/version/type/dependencies only — no
+# devDependencies, no workspace-relative anything) and lets plain `npm install` resolve
+# production-only dependencies directly into `dist/`, rather than shipping the whole pnpm
+# workspace's hoisted node_modules into the image.
+RUN node -e " \
+    const fs = require('fs'); \
+    const pkg = JSON.parse(fs.readFileSync('apps/task-manager/package.json', 'utf8')); \
+    const deployPkg = { \
+      name: pkg.name, \
+      version: pkg.version, \
+      private: true, \
+      type: pkg.type, \
+      dependencies: pkg.dependencies, \
+    }; \
+    fs.writeFileSync('apps/task-manager/dist/package.json', JSON.stringify(deployPkg, null, 2) + '\n'); \
+  "
+WORKDIR /repo/apps/task-manager/dist
+# `slim` has no python3/make/g++, so bullmq's optional native msgpackr-extract binding can't
+# compile here and npm logs a (non-fatal) failure for it — msgpackr transparently falls back to
+# its pure-JS implementation, confirmed working end-to-end against a real Redis in manual testing.
+RUN npm install --omit=dev
+
+FROM node:24.19.0-slim AS runtime
+WORKDIR /app
+COPY --from=build /repo/apps/task-manager/dist ./
+COPY apps/task-manager/Procfile ./Procfile
+
+ENV NODE_ENV=production
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/apps/task-manager/Procfile
+++ b/apps/task-manager/Procfile
@@ -1,0 +1,1 @@
+web: node server.js


### PR DESCRIPTION
## Summary

Replaces the herokuish/buildpack deploy for `task-manager` and `personal-assistant` (synthesize a deploy-only `package.json`, `git push` it to dokku over SSH via `webfactory/ssh-agent`) with the same pattern [yummy-next](https://github.com/yummy-recipes/yummy-next/blob/master/.github/workflows/deploy.yml) uses: build a Docker image, push it to GHCR, then have `dokku/github-action` deploy it via `git:from-image`.

## Changes

- **`apps/task-manager/Dockerfile`**, **`apps/personal-assistant/Dockerfile`** — multi-stage build against the shared pnpm workspace lockfile, `tsc` build, then the same "synthesize a deploy-only `package.json` + `npm install --omit=dev`" trick the old buildpack workflow used, just baked into the image instead of a CI step.
- **`apps/task-manager/Procfile`**, **`apps/personal-assistant/Procfile`** — `web:`/`worker:` process types. Dokku reads these from the deployed image's `WORKDIR` for `git:from-image` deploys, so `personal-assistant` keeps running as a worker with no HTTP healthcheck, same as before.
- **`release_task_manager.yml`**, **`release_personal_assistant.yml`** — kept the existing pnpm install/test steps, replaced the SSH-push tail with `docker/build-push-action` → `ghcr.io/ertrzyiks/ertrzyiks.me/{task-manager,personal-assistant}` → `dokku/github-action`.
- **`.dockerignore`** — keeps the build context (repo root, needed for the workspace lockfile) lean.

## Verification

Built and ran both images locally with `docker build`/`docker run` (not just written on faith):
- **task-manager**: booted against a real Redis container, posted a job through the HTTP API → `201`.
- **personal-assistant**: booted with fake Gmail/Jobs-API creds, created its SQLite dir, and failed at the expected point (bad credentials) — proving the process itself starts correctly.
- Hit and worked around a real issue along the way: `bullmq`'s optional native `msgpackr-extract` binding can't compile on `node:slim` (no python3/make/g++); it silently falls back to its pure-JS implementation, confirmed harmless by the Redis smoke test above.

## Notes for reviewer

- Repo is public, so the GHCR images this pushes are public too — the dokku host shouldn't need a registry login to pull them, but worth a sanity check on the first real deploy.
- `personal-assistant` was already scaled to `worker=1`/`web=0` on the dokku host from the previous buildpack deploy; that's per-app state independent of the builder, so no manual `dokku ps:scale` step is needed for this migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)