### PR TITLE
Hold major typescript bumps until Astro's checker supports TS7

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,13 @@
     ":automergePatch",
     ":automergeMinor",
     ":automergeDigest"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false,
+      "description": "TypeScript 7's native compiler breaks astro check (Cannot read properties of undefined (reading 'fileExists')) in apps/blog and apps/home. Upstream tracking: withastro/astro#17268 (open, 'unable to fix' as of 2026-08). Re-enable once Astro's language-server supports TS7. Follow-up: ertrzyiks/ertrzyiks.me#284."
+    }
   ]
 }


### PR DESCRIPTION
## Why

Renovate PR #196 (\`typescript\` 5.9.3 → 7.0.2) failed CI in both \`Build Home\` and \`Build Blog\`:

\`\`\`
Cannot read properties of undefined (reading 'fileExists')
  at AstroCheck.getTsconfig (@astrojs/language-server@2.16.11 .../check.js:162:73)
\`\`\`

TypeScript 7's native compiler isn't yet supported by Astro's checker (\`@astrojs/check\` / \`@astrojs/language-server\`), which \`apps/blog\` and \`apps/home\` both run via \`astro check && astro build\`.

Confirmed upstream:
- [withastro/astro#17268](https://github.com/withastro/astro/issues/17268) — open, labeled \`triage: unable to fix\`
- [withastro/astro#17336](https://github.com/withastro/astro/issues/17336) — same crash, closed as known issue
- [withastro/astro#17345](https://github.com/withastro/astro/pull/17345) — merged, but only turns the crash into a clearer error message; doesn't add TS7 support

## What

Adds a \`packageRules\` entry to \`renovate.json\` disabling major \`typescript\` version bumps, so Renovate stops proposing the TS7 upgrade until Astro's tooling catches up.

- Closes #196
- Follow-up to revisit in ~2 weeks: #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)