### PR TITLE
Require 30 day minimum release age for Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     ":automergeMinor",
     ":automergeDigest"
   ],
+  "minimumReleaseAge": "30 days",
   "packageRules": [
     {
       "matchPackageNames": ["typescript"],


### PR DESCRIPTION
## Summary
- Set `minimumReleaseAge` to `30 days` at the top level of `renovate.json`, so Renovate holds off proposing any update (major/minor/patch/digest) until the release has been out for 30 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)