### PR TITLE
Enable dokku proxy for task-manager via explicit ports mapping

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -100,6 +100,16 @@ resource "dokku_app" "task_manager" {
   }
 
   domains = ["task-manager.ertrzyiks.me"]
+
+  # Dockerfile-based deploys don't get herokuish's automatic web-port detection, so the proxy
+  # mapping has to be declared explicitly. Matches the `web:` process's EXPOSE 3000 (see
+  # apps/task-manager/Dockerfile).
+  ports = {
+    "80" = {
+      scheme         = "http"
+      container_port = "3000"
+    }
+  }
 }
 
 # Personal Assistant app (email orchestration service, see #250)


### PR DESCRIPTION
## Why

The Dockerfile-based deploy migration (#283, #285) dropped herokuish's automatic web-port detection. `dokku_app.task_manager` never gained an explicit `ports` mapping to replace it, so its proxy routing (domain -> container) has been unmanaged by Terraform since that migration.

## What

Add an explicit `ports` block to `dokku_app.task_manager`, routing host port 80 (http) to container port 3000 — matching the `web:` process in `apps/task-manager/Procfile` and `EXPOSE 3000` in `apps/task-manager/Dockerfile`.

`dokku_app.personal_assistant` is intentionally left unchanged: its `Procfile` only declares a `worker:` process (no inbound HTTP, per the Dockerfile's own comment), so there's no listener for the proxy to route to.

## Note

`terraform/**` changes on `master` auto-apply via `.github/workflows/terraform.yml` with no manual approval gate, so this takes effect on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)