### PR TITLE
Add a health endpoint to personal-assistant; drop Procfile, install with pnpm

### DIFF
--- a/apps/personal-assistant/Dockerfile
+++ b/apps/personal-assistant/Dockerfile
@@ -1,8 +1,10 @@
 # Build context is the repo root (see release_personal_assistant.yml) — this app is a pnpm
 # workspace member and needs the shared lockfile/workspace manifest to install correctly.
 #
-# `server.ts` (built here as `dist/server.js`) is a poller with no inbound HTTP traffic — see
-# Procfile below and README.md for why this ships as a `worker:` process rather than `web:`.
+# `server.ts` (built here as `dist/server.js`) is mainly a poller with no meaningful inbound
+# traffic — its only HTTP surface is the liveness endpoint from healthServer.ts, which is what
+# lets this run as a `web:` process (see Procfile below) so Dokku's proxy has something to
+# route the domain to.
 
 FROM node:24.19.0-slim AS build
 WORKDIR /repo
@@ -48,4 +50,5 @@ COPY --from=build /repo/apps/personal-assistant/dist ./
 COPY apps/personal-assistant/Procfile ./Procfile
 
 ENV NODE_ENV=production
+EXPOSE 3000
 CMD ["node", "server.js"]

--- a/apps/personal-assistant/Dockerfile
+++ b/apps/personal-assistant/Dockerfile
@@ -2,9 +2,9 @@
 # workspace member and needs the shared lockfile/workspace manifest to install correctly.
 #
 # `server.ts` (built here as `dist/server.js`) is mainly a poller with no meaningful inbound
-# traffic — its only HTTP surface is the liveness endpoint from healthServer.ts, which is what
-# lets this run as a `web:` process (see Procfile below) so Dokku's proxy has something to
-# route the domain to.
+# traffic — its only HTTP surface is the liveness endpoint from healthServer.ts. No Procfile:
+# Dokku treats a Dockerfile app's CMD as its `web` process type by default (and proxies it
+# accordingly) whenever there's no Procfile to say otherwise, so one isn't needed here.
 
 FROM node:24.19.0-slim AS build
 WORKDIR /repo
@@ -23,10 +23,8 @@ RUN pnpm install --frozen-lockfile
 COPY apps/personal-assistant apps/personal-assistant
 RUN pnpm --filter personal-assistant build
 
-# Dokku's Dockerfile builder reads a `Procfile` from the image's WORKDIR (see Procfile below), the
-# same mechanism the old herokuish buildpack deploy relied on — so, like that deploy, this
-# synthesizes a deploy-only `package.json` (name/version/type/dependencies only — no
-# devDependencies, no workspace-relative anything) and lets plain `npm install` resolve
+# Synthesizes a deploy-only `package.json` (name/version/type/dependencies only — no
+# devDependencies, no workspace-relative anything) and lets `pnpm install` resolve
 # production-only dependencies directly into `dist/`, rather than shipping the whole pnpm
 # workspace's hoisted node_modules into the image.
 RUN node -e " \
@@ -42,12 +40,11 @@ RUN node -e " \
     fs.writeFileSync('apps/personal-assistant/dist/package.json', JSON.stringify(deployPkg, null, 2) + '\n'); \
   "
 WORKDIR /repo/apps/personal-assistant/dist
-RUN npm install --omit=dev
+RUN pnpm install --prod
 
 FROM node:24.19.0-slim AS runtime
 WORKDIR /app
 COPY --from=build /repo/apps/personal-assistant/dist ./
-COPY apps/personal-assistant/Procfile ./Procfile
 
 ENV NODE_ENV=production
 EXPOSE 3000

--- a/apps/personal-assistant/Procfile
+++ b/apps/personal-assistant/Procfile
@@ -1,1 +1,0 @@
-web: node server.js

--- a/apps/personal-assistant/Procfile
+++ b/apps/personal-assistant/Procfile
@@ -1,1 +1,1 @@
-worker: node server.js
+web: node server.js

--- a/apps/personal-assistant/src/healthServer.test.ts
+++ b/apps/personal-assistant/src/healthServer.test.ts
@@ -1,0 +1,36 @@
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHealthServer } from "./healthServer.js";
+import type { Server } from "node:http";
+
+describe("healthServer", () => {
+  let server: Server | undefined;
+
+  afterEach(() => {
+    server?.close();
+    server = undefined;
+  });
+
+  async function listen(): Promise<number> {
+    server = createHealthServer();
+    await new Promise<void>((resolve) => server?.listen(0, resolve));
+    return (server?.address() as AddressInfo).port;
+  }
+
+  it("responds 200 with a status body on GET /health", async () => {
+    const port = await listen();
+
+    const res = await fetch(`http://localhost:${port}/health`);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+  });
+
+  it("responds 404 for any other path", async () => {
+    const port = await listen();
+
+    const res = await fetch(`http://localhost:${port}/other`);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/personal-assistant/src/healthServer.ts
+++ b/apps/personal-assistant/src/healthServer.ts
@@ -1,0 +1,38 @@
+import { createServer, type Server } from "node:http";
+import type { Logger } from "./poller.js";
+
+export interface HealthServer {
+  close(): void;
+}
+
+/**
+ * personal-assistant otherwise has no HTTP surface (see Dockerfile) — this exists purely so
+ * Dokku's proxy has something to route the domain to and health-check against. Responds to
+ * GET /health with 200 whenever the process is up; there's no dependency check (Gmail, Jobs
+ * API, sqlite) behind it, just liveness.
+ */
+export function createHealthServer(): Server {
+  return createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/health") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "ok" }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+}
+
+export function startHealthServer(port: number, logger?: Logger): HealthServer {
+  const server = createHealthServer();
+
+  server.listen(port, () => {
+    logger?.info(`health server listening on port ${port}`);
+  });
+
+  return {
+    close() {
+      server.close();
+    },
+  };
+}

--- a/apps/personal-assistant/src/server.ts
+++ b/apps/personal-assistant/src/server.ts
@@ -1,11 +1,13 @@
 import { loadConfig } from "./config.js";
 import { createGmailClient } from "./gmailClient.js";
+import { startHealthServer } from "./healthServer.js";
 import { createJobsApiClient } from "./jobsApiClient.js";
 import type { Logger } from "./poller.js";
 import { startPolling } from "./runner.js";
 import { createStore } from "./store.js";
 
 const config = loadConfig();
+const port = Number(process.env.PORT ?? 3000);
 
 const logger: Logger = {
   info: (message) => console.log(`[personal-assistant] ${message}`),
@@ -22,10 +24,12 @@ logger.info(
 );
 
 const runner = startPolling({ gmail, jobsApi, store, logger }, config.pollIntervalMs);
+const health = startHealthServer(port, logger);
 
 function shutdown() {
   logger.info("shutting down");
   runner.stop();
+  health.close();
   store.close();
   process.exit(0);
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -126,6 +126,17 @@ resource "dokku_app" "personal_assistant" {
 
   domains = ["personal-assistant.ertrzyiks.me"]
 
+  # Now runs a `web:` process with a /health liveness endpoint (see
+  # apps/personal-assistant/src/healthServer.ts) alongside the poller, so it needs the same
+  # explicit proxy mapping as task-manager — Dockerfile-based deploys don't get herokuish's
+  # automatic web-port detection.
+  ports = {
+    "80" = {
+      scheme         = "http"
+      container_port = "3000"
+    }
+  }
+
   storage = {
     personal-assistant = {
       mount_path = "/app/data"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -126,17 +126,6 @@ resource "dokku_app" "personal_assistant" {
 
   domains = ["personal-assistant.ertrzyiks.me"]
 
-  # Now runs a `web:` process with a /health liveness endpoint (see
-  # apps/personal-assistant/src/healthServer.ts) alongside the poller, so it needs the same
-  # explicit proxy mapping as task-manager — Dockerfile-based deploys don't get herokuish's
-  # automatic web-port detection.
-  ports = {
-    "80" = {
-      scheme         = "http"
-      container_port = "3000"
-    }
-  }
-
   storage = {
     personal-assistant = {
       mount_path = "/app/data"


### PR DESCRIPTION
## ⚠️ Won't be reachable until a manual host-side step runs

personal-assistant's Dokku process scale is separate, per-host state — currently pinned to `worker=1/web=0` from the original buildpack deploy (see the comment in `.github/workflows/release_personal_assistant.yml`). That state persists across deploys regardless of what the deployed image's process types are, and **nothing in this repo manages it** — not this PR, not Terraform (the `aliksend/dokku` provider has no scale/process attribute at all).

So even after this merges, `/health` won't be reachable through the proxy until someone runs, on the Dokku host:
```
dokku ps:scale personal-assistant web=1 worker=0
```
Flagging this rather than silently assuming the Procfile/CMD change flips it on its own.

## Why (original)

personal-assistant had zero HTTP surface — it's a poller with no inbound traffic — so there was nothing for Dokku's proxy to route its domain (`personal-assistant.ertrzyiks.me`) to.

## What

- **`src/healthServer.ts`** (+ test): minimal `GET /health` liveness endpoint using plain `node:http`, no new dependency. Returns `{ status: "ok" }` / 200, 404 for anything else.
- **`src/server.ts`**: starts the health server on `PORT` (default 3000) alongside the existing poller; closes it on shutdown.
- **`Procfile`**: deleted. Dokku treats a Dockerfile app's `CMD` as its `web` process type by default whenever there's no `Procfile` (confirmed against Dokku's docs), so an explicit `web:` Procfile line was redundant.
- **`Dockerfile`**: adds `EXPOSE 3000`; drops the `COPY .../Procfile` step; swaps the deploy-stage `npm install --omit=dev` for `pnpm install --prod`, consistent with the same change made to task-manager (#292).
- Terraform's `ports` block was tried and then explicitly reverted per request — this app's proxy port mapping is unmanaged by Terraform, same as task-manager.

## Testing

- `pnpm --filter personal-assistant test` — 41/41 passing (7 files, incl. `healthServer.test.ts`)
- `pnpm --filter personal-assistant exec tsc --noEmit` — clean
- `pnpm --filter personal-assistant build` — clean, `dist/healthServer.js` present
- Verified `pnpm install --prod` against a standalone copy of the synthesized deploy `package.json` resolves the same runtime deps with devDependencies excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)