### PR TITLE
Fix pnpm prod install aborting in Dockerfile deploy stage

### DIFF
--- a/apps/personal-assistant/Dockerfile
+++ b/apps/personal-assistant/Dockerfile
@@ -40,7 +40,16 @@ RUN node -e " \
     fs.writeFileSync('apps/personal-assistant/dist/package.json', JSON.stringify(deployPkg, null, 2) + '\n'); \
   "
 WORKDIR /repo/apps/personal-assistant/dist
-RUN pnpm install --prod
+# `--ignore-workspace`: this dist/ package.json isn't a declared pnpm-workspace.yaml member, but
+# without the flag pnpm still finds the workspace root above it and runs the install scoped to
+# "all workspace projects" instead of this directory alone — which, since dist/'s lockfile-less
+# package.json doesn't match what's on disk at the real workspace root, makes pnpm want to purge
+# and rebuild /repo/node_modules and abort with ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY (no
+# TTY to confirm the purge in a `docker build`), rather than installing anything into dist/ at all.
+#
+# `--ignore-scripts`: matches task-manager's Dockerfile — no dependency here needs a build step,
+# but skipping install scripts by default keeps this resilient if one gets added later.
+RUN pnpm install --prod --ignore-workspace --ignore-scripts
 
 FROM node:24.19.0-slim AS runtime
 WORKDIR /app

--- a/apps/task-manager/Dockerfile
+++ b/apps/task-manager/Dockerfile
@@ -39,12 +39,19 @@ RUN node -e " \
     fs.writeFileSync('apps/task-manager/dist/package.json', JSON.stringify(deployPkg, null, 2) + '\n'); \
   "
 WORKDIR /repo/apps/task-manager/dist
-# `slim` has no python3/make/g++, so bullmq's optional native msgpackr-extract binding can't
-# compile here. pnpm skips (rather than attempts and fails) build scripts for dependencies by
-# default, so unlike the old npm install this doesn't even try — msgpackr transparently falls
-# back to its pure-JS implementation, confirmed working end-to-end against a real Redis in
-# manual testing.
-RUN pnpm install --prod
+# `--ignore-workspace`: this dist/ package.json isn't a declared pnpm-workspace.yaml member, but
+# without the flag pnpm still finds the workspace root above it and runs the install scoped to
+# "all workspace projects" instead of this directory alone — which, since dist/'s lockfile-less
+# package.json doesn't match what's on disk at the real workspace root, makes pnpm want to purge
+# and rebuild /repo/node_modules and abort with ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY (no
+# TTY to confirm the purge in a `docker build`), rather than installing anything into dist/ at all.
+#
+# `--ignore-scripts`: `slim` has no python3/make/g++, so bullmq's optional native msgpackr-extract
+# binding can't compile here — msgpackr transparently falls back to its pure-JS implementation,
+# confirmed working end-to-end against a real Redis in manual testing. `--ignore-workspace` also
+# stops pnpm from reading pnpm-workspace.yaml's `allowBuilds`, so without `--ignore-scripts` pnpm
+# now hard-fails with ERR_PNPM_IGNORED_BUILDS instead of silently skipping the build as before.
+RUN pnpm install --prod --ignore-workspace --ignore-scripts
 
 FROM node:24.19.0-slim AS runtime
 WORKDIR /app


### PR DESCRIPTION
## Problem

Every deploy of both `task-manager` and `personal-assistant` is currently broken. The Docker build fails at the deploy-stage install step:

```
[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] Aborted removal of modules directory due to no TTY
```

See the failing run: https://github.com/ertrzyiks/ertrzyiks.me/actions/runs/31114914781/job/92661848040

## Root cause

Both Dockerfiles run `pnpm install --prod` inside `apps/*/dist` — a directory nested under the repo's pnpm workspace root, but not itself a declared `pnpm-workspace.yaml` member. pnpm still walks up and finds the workspace root, so it scopes the install to *all* workspace projects rather than just `dist/`, and — since `dist/`'s synthesized package.json doesn't match what's already installed at the real workspace root — decides it needs to purge and rebuild `/repo/node_modules`. That needs an interactive confirmation, which a non-TTY `docker build` can't give, so it aborts.

Reproduced locally with plain `docker build` against master's current Dockerfiles (both apps fail identically).

## Fix

- Add `--ignore-workspace` so pnpm treats `dist/`'s package.json as a standalone project, sidestepping the workspace-root confusion entirely.
- That flag also stops pnpm from reading `pnpm-workspace.yaml`'s `allowBuilds`, which surfaces a second, separate failure for task-manager (`ERR_PNPM_IGNORED_BUILDS` on `msgpackr-extract`). Add `--ignore-scripts` to resolve it — this is the behavior the Dockerfile's own comment already says it wants (skip the native build; msgpackr falls back to pure JS, "confirmed working end-to-end against a real Redis in manual testing"). Added to personal-assistant's Dockerfile too for consistency, even though it has no scripted dependencies today.

## Verification

Built and ran both images locally end-to-end:
- `docker build` succeeds for both `apps/task-manager/Dockerfile` and `apps/personal-assistant/Dockerfile`.
- Dependencies install correctly: `bullmq`/`fastify`/`ioredis` present for task-manager, `googleapis` present for personal-assistant.
- `docker run` boots each image to the expected "missing required env var" error (`REDIS_URL`/`GMAIL_CLIENT_ID`) rather than a missing-module crash — confirming the installed deps actually resolve at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)